### PR TITLE
fix: handle phrases with apostrophes

### DIFF
--- a/edxsearch/__init__.py
+++ b/edxsearch/__init__.py
@@ -1,3 +1,3 @@
 """ Container module for testing / demoing search """
 
-__version__ = '3.3.0'
+__version__ = '3.4.0'

--- a/search/result_processor.py
+++ b/search/result_processor.py
@@ -131,7 +131,12 @@ class SearchResultProcessor:
             return None
 
         match_phrases = [self._match_phrase]
-        separate_phrases = list(shlex.split(self._match_phrase))
+        try:
+            separate_phrases = list(shlex.split(self._match_phrase))
+        # This can happen when the phrase contains an apostrophe - the POSIX mode does not allow unclosed quotations.
+        except ValueError:
+            separate_phrases = list(shlex.split(self._match_phrase, posix=False))
+
         if len(separate_phrases) > 1:
             match_phrases.extend(separate_phrases)
         else:

--- a/search/tests/test_search_result_processor.py
+++ b/search/tests/test_search_result_processor.py
@@ -267,6 +267,30 @@ class SearchResultProcessorTests(TestCase):
         srp = SearchResultProcessor(test_result, 'Just a line')
         self.assertIn(ELLIPSIS, srp.excerpt)
 
+    @ddt.data(
+        ("shouldn't", "This <b>shouldn't</b> have failed."),
+        ("shouldn\'t", " This <b>shouldn't</b> have failed."),
+        ('"shouldn\'t have"', "This <b>shouldn't have</b> failed."),
+        ("shouldn\\'t\\'ve", "<b>shouldn't've</b> failed."),  # An even number of apostrophes needs to be escaped.
+        ('"shouldn\'t\'ve failed"', "<b>shouldn't've failed</b>."),
+        ("shou\'dn\'t\'ve", "This <b>shou'dn't've</b> failed."),
+        ('"shou\'dn\'t\'ve failed"', "This <b>shou'dn't've failed</b>."),
+    )
+    @ddt.unpack
+    def test_excerpt_apostrophe(self, search_phrase, expected_excerpt):
+        test_result = {
+            "content": {
+                "notes": (
+                    "This should not have failed. "
+                    "This shouldn't have failed. "
+                    "This shouldn't've failed. "
+                    "This shou'dn't've failed."
+                )
+            }
+        }
+        srp = SearchResultProcessor(test_result, search_phrase)
+        self.assertIn(expected_excerpt, srp.excerpt)
+
 
 class TestSearchResultProcessor(SearchResultProcessor):
     """


### PR DESCRIPTION
## Description
We're using [shlex](https://docs.python.org/3.8/library/shlex.html) to split phrases. It uses the POSIX mode by default, which is throwing an exception when there are unclosed quotes in phrases. This escapes such quotes, so the phrases with apostrophes can be split correctly.

## Supporting information
OSPR ticket: [OSPR-6172](https://openedx.atlassian.net/browse/OSPR-6172)
OpenCraft Jira ticket: [BB-4994](https://tasks.opencraft.com/browse/BB-4994)

## Known issues
The ElasticSearch connection was not working for me with the most recent devstack version. I had to add this to `lms/envs/private.py` and `cms/envs/private.py`:
```python
ELASTIC_SEARCH_CONFIG = [
    {
        'use_ssl': False,
        'host': 'edx.devstack.elasticsearch710',
        'port': 9200
    }
]
```

## Testing instructions
1. Enable `FEATURES['ENABLE_COURSEWARE_SEARCH']` in LMS.
1. Enable `FEATURES['ENABLE_COURSEWARE_INDEX']` in Studio.
1. Create a Blank Common Problem XBlock with the following content:
   ```
   This should not have failed.
   This shouldn't have failed.
   This shouldn't've failed.
   This shou'dn't've failed.
   ```
1. Go to your [dashboard](http://localhost:18000/dashboard) in LMS and search for the following phrases:
   - `"should not"`
   - `shouldn't`
   - `shouldn\'t`
   - `"shouldn't have"`
   - `shouldn\'t\'ve`
   - `"shouldn't've failed"`
   - `shou'dn't've`
   - `shou\'dn\'t\'ve`
   - `"shou'dn't've failed"`

## Deadline
"None"

## Reviewers
- [x] @alfredchavez 
- [ ] edX reviewer (TBD)