### PR TITLE
Fix issues with setuptools pin

### DIFF
--- a/edxsearch/__init__.py
+++ b/edxsearch/__init__.py
@@ -1,3 +1,3 @@
 """ Container module for testing / demoing search """
 
-__version__ = '4.0.0'
+__version__ = '3.2.0'

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -22,7 +22,7 @@ idna==3.3
     # via requests
 packaging==21.3
     # via tox
-platformdirs==2.4.1
+platformdirs==2.5.0
     # via virtualenv
 pluggy==1.0.0
     # via tox

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -199,7 +199,7 @@ pep517==0.12.0
     #   pip-tools
 pip-tools==6.5.1
     # via -r requirements/pip-tools.txt
-platformdirs==2.4.1
+platformdirs==2.5.0
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt

--- a/requirements/pip.in
+++ b/requirements/pip.in
@@ -1,4 +1,5 @@
 # Core dependencies for installing other packages
+-c constraints.txt
 
 pip
 setuptools

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -10,5 +10,7 @@ wheel==0.37.1
 # The following packages are considered to be unsafe in a requirements file:
 pip==22.0.3
     # via -r requirements/pip.in
-setuptools==60.8.1
-    # via -r requirements/pip.in
+setuptools==59.8.0
+    # via
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   -r requirements/pip.in

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -126,7 +126,7 @@ pbr==5.8.1
     # via
     #   -r requirements/testing.txt
     #   stevedore
-platformdirs==2.4.1
+platformdirs==2.5.0
     # via pylint
 pluggy==1.0.0
     # via


### PR DESCRIPTION
Major version was bumped in this [PR](https://github.com/openedx/edx-search/pull/120) which was a mistake. This PR fixes that mistake. Also `setuptools` constraint was not advertised in the `pip.in` requirements file which is also fixed in this PR.