### PR TITLE
fix: do not decorate `ELLIPSIS` with `<b>` tags

### DIFF
--- a/edxsearch/__init__.py
+++ b/edxsearch/__init__.py
@@ -1,3 +1,3 @@
 """ Container module for testing / demoing search """
 
-__version__ = '3.2.0'
+__version__ = '3.3.0'

--- a/search/result_processor.py
+++ b/search/result_processor.py
@@ -142,9 +142,9 @@ class SearchResultProcessor:
             match_phrases,
             DESIRED_EXCERPT_LENGTH
         )
-        excerpt_text = ELLIPSIS.join(matches)
 
-        for match_word in match_phrases:
-            excerpt_text = SearchResultProcessor.decorate_matches(excerpt_text, match_word)
+        for i, _ in enumerate(matches):
+            for match_word in match_phrases:
+                matches[i] = SearchResultProcessor.decorate_matches(matches[i], match_word)
 
-        return excerpt_text
+        return ELLIPSIS.join(matches)

--- a/search/tests/test_search_result_processor.py
+++ b/search/tests/test_search_result_processor.py
@@ -4,7 +4,7 @@ import ddt
 
 from django.test import TestCase
 from django.test.utils import override_settings
-from search.result_processor import SearchResultProcessor
+from search.result_processor import SearchResultProcessor, ELLIPSIS
 
 
 # Any class that inherits from TestCase will cause too-many-public-methods pylint error
@@ -249,6 +249,23 @@ class SearchResultProcessorTests(TestCase):
         }
         srp = SearchResultProcessor(test_result, search_phrase)
         self.assertIn(expected_excerpt, srp.excerpt)
+
+    def test_excerpt_ellipsis_undecorated(self):
+        """
+        Multiple matches are joined with `ELLIPSIS` as a separator.
+        This verifies that the `ELLIPSIS` is not decorated with the HTML `<b>` tag when it matches the search phrase.
+
+        E.g. when `a` was in the search phrases before, it was resulting in text like `<sp<b>a</b>n`, which is not valid
+        HTML.
+        """
+        test_result = {
+            "content": {
+                "a": "Just a line of text.",
+                "b": "Just a line of different text.",
+            }
+        }
+        srp = SearchResultProcessor(test_result, 'Just a line')
+        self.assertIn(ELLIPSIS, srp.excerpt)
 
 
 class TestSearchResultProcessor(SearchResultProcessor):

--- a/search/utils.py
+++ b/search/utils.py
@@ -1,7 +1,7 @@
 """ Utility classes to support others """
 
 import importlib
-import collections
+from collections.abc import Iterable
 
 
 def _load_class(class_path, default):
@@ -21,7 +21,7 @@ def _load_class(class_path, default):
 
 def _is_iterable(item):
     """ Checks if an item is iterable (list, tuple, generator), but not string """
-    return isinstance(item, collections.Iterable) and not isinstance(item, str)
+    return isinstance(item, Iterable) and not isinstance(item, str)
 
 
 class ValueRange:


### PR DESCRIPTION
Multiple matches are merged with `ELLIPSIS` as a separator.
This reverses the order of operations so that the matches are decorated before they are merged. This way, the content of `ELLIPSIS` is not decorated with HTML `<b>` tags.

Jira ticket (nonpublic): [BB-5589](https://tasks.opencraft.com/browse/BB-5589)

### Testing instructions
1. Add the following to `{lms,cms}/envs/private.py`:
   ```python
   from .common import FEATURES

   FEATURES['ENABLE_COURSEWARE_SEARCH'] = True
   FEATURES['ENABLE_COURSEWARE_SEARCH_FOR_COURSE_STAFF'] = True
   FEATURES['ENABLE_DASHBOARD_SEARCH'] = True
   FEATURES['ENABLE_COURSE_DISCOVERY'] = True
   FEATURES['ENABLE_COURSEWARE_INDEX'] = True
   FEATURES['ENABLE_LIBRARY_INDEX'] = True

   ELASTIC_SEARCH_CONFIG = [
       {
           'use_ssl': False,
           'host': 'edx.devstack.elasticsearch710',
           'port': 9200
       }
   ]
   ```
2. Go to the [demo course in Studio](http://localhost:18010/course/course-v1:edX+DemoX+Demo_Course) and click the "Reindex" button.
3. Go to the [Dashboard in LMS](http://localhost:18000/dashboard) and type `Passing a course` into the search field.
4. Results should not contain broken HTML code.

### Reviewers
- [x] @xitij2000 
- [ ] edX reviewer/CC: TBD