### PR TITLE
fix: courses are visible /courses when shouldn't

### DIFF
--- a/search/api.py
+++ b/search/api.py
@@ -99,6 +99,14 @@ def course_discovery_search(search_term=None, size=20, from_=0, field_dictionary
     if not getattr(settings, "SEARCH_SKIP_ENROLLMENT_START_DATE_FILTERING", False):
         use_field_dictionary["enrollment_start"] = DateRange(None, datetime.utcnow())
 
+    # Here we check if there is a filter value for 'catalog_visibility'
+    # And then check if there a value in exclude dict
+    # If not then we only return courses with 'catalog_visibility' set to 'both'
+    # By excluding all other possible values which are "none" or "about"
+    if "catalog_visibility" not in use_field_dictionary:
+        if "catalog_visibility" not in exclude_dictionary:
+            exclude_dictionary["catalog_visibility"] = ["none", "about"]
+
     searcher = SearchEngine.get_search_engine(
         getattr(settings, "COURSEWARE_INFO_INDEX_NAME", "course_info")
     )


### PR DESCRIPTION
  When discovery service is enabled, then the /courses page in
  LMS will not be filled with courses **initially**[^1], so that a
  frontend script will send XHR request to fetch courses using
  POST /search/course_discovery/[^2], the LMS then will proxy the
  request to edx-search[^3].

[^1]:https://github.com/openedx/edx-platform/blob/db32ff2cdf678fa8edd12c9da76a76eef0478614/lms/djangoapps/courseware/views/views.py#L281-L283
[^2]:https://github.com/openedx/edx-platform/blob/db32ff2cdf678fa8edd12c9da76a76eef0478614/lms/static/js/discovery/models/course_discovery.js#L9-L17
[^3]:https://github.com/openedx/edx-platform/blob/9f904e80f09555ef78656ce59d283af24fd13221/lms/urls.py#L133

  The probelm is when a course is hidden using advance setting,
  in studio, the edx-search is not affected or is not concern with
  that setting.

  So here I am adding an edge case, where if in the search
  request the 'catalog_visibility' is not set, it will default
  to 'both' meaning, by default it will *only* return courses
  that are suppose to be visible in the catalog.

  This fixes openedx/build-test-release-wg/issues/164.