### PR TITLE
fix: Install pip and pip-tools in upgrade script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,8 @@ upgrade: ## update the requirements/*.txt files with the latest packages satisfy
 	# Make sure to compile files after any other files they include!
 	pip-compile --rebuild --allow-unsafe --rebuild -o requirements/pip.txt requirements/pip.in
 	pip-compile --rebuild --upgrade -o requirements/pip-tools.txt requirements/pip-tools.in
+	pip install -qr requirements/pip.txt
+	pip install -qr requirements/pip-tools.txt
 	pip-compile --rebuild --upgrade -o requirements/base.txt requirements/base.in
 	pip-compile --rebuild --upgrade -o requirements/testing.txt requirements/testing.in
 	pip-compile --rebuild --upgrade -o requirements/quality.txt requirements/quality.in


### PR DESCRIPTION
Updated the upgrade target script to check the compatibility of upgraded pip and pip-tools versions.
For reference, look at this [PR](https://github.com/openedx/edx-repo-health/pull/271) for new check added in edx-repo-health. 
JIRA: https://2u-internal.atlassian.net/browse/BOM-3423