### PR TITLE
feat: prefixed index names for ElasticSearch.

### DIFF
--- a/search/tests/test_engines.py
+++ b/search/tests/test_engines.py
@@ -11,15 +11,23 @@ from datetime import datetime
 from unittest.mock import patch
 from django.test import TestCase
 from django.test.utils import override_settings
-from elasticsearch import exceptions
+from elasticsearch import exceptions, Elasticsearch
 from elasticsearch.helpers import BulkIndexError
 
 from search.api import perform_search, NoSearchEngineError
 from search.elastic import RESERVED_CHARACTERS
 from search.tests.mock_search_engine import MockSearchEngine, json_date_to_datetime
 from search.tests.tests import MockSearchTests
-from search.tests.utils import ErroringElasticImpl, SearcherMixin
+from search.tests.utils import ErroringElasticImpl, SearcherMixin, TEST_INDEX_NAME
+from django.core.cache import cache
 
+
+@override_settings(ELASTICSEARCH_INDEX_PREFIX='prefixed_')
+@override_settings(SEARCH_ENGINE="search.tests.utils.ForceRefreshElasticSearchEngine")
+class ElasticSearchPrefixTests(MockSearchTests):
+    @property
+    def index_name(self):
+        return f"prefixed_{TEST_INDEX_NAME}"
 
 @override_settings(SEARCH_ENGINE="search.tests.utils.ForceRefreshElasticSearchEngine")
 class ElasticSearchTests(MockSearchTests):

--- a/search/tests/tests.py
+++ b/search/tests/tests.py
@@ -27,6 +27,11 @@ from .mock_search_engine import MockSearchEngine
 @override_settings(MOCK_SEARCH_BACKING_FILE=None)
 class MockSearchTests(TestCase, SearcherMixin):
     """ Test operation of search activities """
+
+    @property
+    def index_name(self):
+        return TEST_INDEX_NAME
+    
     @property
     def _is_elastic(self):
         """ check search engine implementation, to manage cleanup differently """
@@ -39,11 +44,11 @@ class MockSearchTests(TestCase, SearcherMixin):
         if self._is_elastic:
             _elasticsearch = Elasticsearch()
             # Make sure that we are fresh
-            _elasticsearch.indices.delete(index=TEST_INDEX_NAME, ignore=[400, 404])
+            _elasticsearch.indices.delete(index=self.index_name, ignore=[400, 404])
 
             config_body = {}
             # ignore unexpected-keyword-arg; ES python client documents that it can be used
-            _elasticsearch.indices.create(index=TEST_INDEX_NAME, ignore=400, body=config_body)
+            _elasticsearch.indices.create(index=self.index_name, ignore=400, body=config_body)
         else:
             MockSearchEngine.destroy()
         self._searcher = None
@@ -55,7 +60,7 @@ class MockSearchTests(TestCase, SearcherMixin):
         if self._is_elastic:
             _elasticsearch = Elasticsearch()
             # ignore unexpected-keyword-arg; ES python client documents that it can be used
-            _elasticsearch.indices.delete(index=TEST_INDEX_NAME, ignore=[400, 404])
+            _elasticsearch.indices.delete(index=self.index_name, ignore=[400, 404])
         else:
             MockSearchEngine.destroy()
 


### PR DESCRIPTION
## Description

Add a new setting `ELASTIC_SEARCH_INDEX_PREFIX` that will be prepended to all ElasticSearch indexes. This helps with multitenancy so that indexes can be split per "tenant"

## Testing Instructions

- Proofread the code
- It should be enough to run the tests here as they are fairly extensive with `make test_with_es`

## Supporting information

- [Related Grove PR](https://gitlab.com/opencraft/dev/grove/-/merge_requests/131) that will utilize this feature.