### PR TITLE
Log detailed elasticsearch params

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
-.PHONY: clean quality requirements validate test test-python quality-python install-local
+.PHONY: clean quality requirements validate test test-with-es quality-python install-local
 
 clean:
 	find . -name '__pycache__' -exec rm -rf {} +
 	find . -name '*.pyc' -exec rm -f {} +
 	find . -name '*.pyo' -exec rm -f {} +
-	find . -name '*~' -exec rm -f {} +	
+	find . -name '*~' -exec rm -f {} +
 	coverage erase
 	rm -rf coverage htmlcov
 	rm -fr build/
@@ -51,10 +51,7 @@ upgrade: ## update the requirements/*.txt files with the latest packages satisfy
 	sed '/^[dD]jango==/d' requirements/testing.txt > requirements/testing.tmp
 	mv requirements/testing.tmp requirements/testing.txt
 
-test-python: clean ## run tests using pytest and generate coverage report
-	pytest
-
-test: test-python ## run tests and generate coverage report
+test: test_with_es ## run tests and generate coverage report
 
 install-local: ## installs your local edx-search into the LMS and CMS python virtualenvs
 	docker exec -t edx.devstack.lms bash -c '. /edx/app/edxapp/venvs/edxapp/bin/activate && cd /edx/app/edxapp/edx-platform && pip uninstall -y edx-search && pip install -e /edx/src/edx-search && pip freeze | grep edx-search'

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: clean quality requirements validate test test-python quality-python
+.PHONY: clean quality requirements validate test test-python quality-python install-local
 
 clean:
 	find . -name '__pycache__' -exec rm -rf {} +
@@ -55,3 +55,7 @@ test-python: clean ## run tests using pytest and generate coverage report
 	pytest
 
 test: test-python ## run tests and generate coverage report
+
+install-local: ## installs your local edx-search into the LMS and CMS python virtualenvs
+	docker exec -t edx.devstack.lms bash -c '. /edx/app/edxapp/venvs/edxapp/bin/activate && cd /edx/app/edxapp/edx-platform && pip uninstall -y edx-search && pip install -e /edx/src/edx-search && pip freeze | grep edx-search'
+	docker exec -t edx.devstack.cms bash -c '. /edx/app/edxapp/venvs/edxapp/bin/activate && cd /edx/app/edxapp/edx-platform && pip uninstall -y edx-search && pip install -e /edx/src/edx-search && pip freeze | grep edx-search'

--- a/edxsearch/__init__.py
+++ b/edxsearch/__init__.py
@@ -1,3 +1,3 @@
 """ Container module for testing / demoing search """
 
-__version__ = '3.6.0'
+__version__ = '3.7.0'

--- a/search/api.py
+++ b/search/api.py
@@ -62,6 +62,7 @@ def perform_course_search(
     )
     if not searcher:
         raise NoSearchEngineError("No search engine specified in settings.SEARCH_ENGINE")
+    log_search_params = getattr(settings, "SEARCH_COURSEWARE_CONTENT_LOG_PARAMS", False)
 
     results = searcher.search(
         query_string=search_term,
@@ -70,6 +71,7 @@ def perform_course_search(
         exclude_dictionary=exclude_dictionary,
         size=size,
         from_=from_,
+        log_search_params=log_search_params,
     )
 
     # post-process the result

--- a/search/api.py
+++ b/search/api.py
@@ -41,7 +41,7 @@ class NoSearchEngineError(Exception):
     """
 
 
-def perform_search(
+def perform_course_search(
         search_term,
         user=None,
         size=10,

--- a/search/api.py
+++ b/search/api.py
@@ -63,8 +63,8 @@ def perform_course_search(
     if not searcher:
         raise NoSearchEngineError("No search engine specified in settings.SEARCH_ENGINE")
 
-    results = searcher.search_string(
-        search_term,
+    results = searcher.search(
+        query_string=search_term,
         field_dictionary=field_dictionary,
         filter_dictionary=filter_dictionary,
         exclude_dictionary=exclude_dictionary,

--- a/search/elastic.py
+++ b/search/elastic.py
@@ -477,6 +477,7 @@ class ElasticSearchEngine(SearchEngine):
                aggregation_terms=None,
                exclude_ids=None,
                use_field_match=False,
+               log_search_params=False,
                **kwargs):  # pylint: disable=arguments-differ, unused-argument
         """
         Implements call to search the index for the desired content.
@@ -652,6 +653,9 @@ class ElasticSearchEngine(SearchEngine):
         body = {"query": query}
         if aggregation_terms:
             body["aggs"] = _process_aggregation_terms(aggregation_terms)
+
+        if log_search_params:
+            log.info(f"full elastic search body {body}")
 
         try:
             es_response = self._es.search(index=self._prefixed_index_name, body=body, **kwargs)

--- a/search/search_engine_base.py
+++ b/search/search_engine_base.py
@@ -48,6 +48,7 @@ class SearchEngine:
                filter_dictionary=None,
                exclude_dictionary=None,
                aggregation_terms=None,
+               log_search_params=False,
                **kwargs):  # pylint: disable=too-many-arguments
         """
         Search for matching documents within the search index.

--- a/search/tests/mock_search_engine.py
+++ b/search/tests/mock_search_engine.py
@@ -340,6 +340,7 @@ class MockSearchEngine(SearchEngine):
                filter_dictionary=None,
                exclude_dictionary=None,
                aggregation_terms=None,
+               log_search_params=False,
                **kwargs):  # pylint: disable=too-many-arguments
         """
         Perform search upon documents within index.

--- a/search/tests/test_engines.py
+++ b/search/tests/test_engines.py
@@ -13,7 +13,7 @@ from django.test import TestCase
 from django.test.utils import override_settings
 from elasticsearch import exceptions
 from elasticsearch.helpers import BulkIndexError
-from search.api import NoSearchEngineError, perform_search
+from search.api import NoSearchEngineError, perform_course_search
 from search.elastic import RESERVED_CHARACTERS
 from search.tests.mock_search_engine import (MockSearchEngine,
                                              json_date_to_datetime)
@@ -238,7 +238,7 @@ class TestNone(TestCase):
     def test_perform_search(self):
         """ search opertaion should yeild an exception with no search engine """
         with self.assertRaises(NoSearchEngineError):
-            perform_search("abc test")
+            perform_course_search("abc test")
 
 
 @override_settings(SEARCH_ENGINE="search.elastic.ElasticSearchEngine")

--- a/search/tests/tests.py
+++ b/search/tests/tests.py
@@ -130,6 +130,15 @@ class MockSearchTests(TestCase, SearcherMixin):
         response = self.searcher.search_string(test_string)
         self.assertEqual(response["total"], 3)
 
+    def test_log_params(self):
+        """ Test that if you turn on detailed logging, search doesn't explode. """
+        test_string = "A test string"
+        self.searcher.index([{"content": {"name": test_string}}])
+
+        # search string
+        response = self.searcher.search(query_string=test_string, log_search_params=True)
+        self.assertEqual(response["total"], 1)
+
     def test_field(self):
         """ test matching on a field """
         test_string = "A test string"

--- a/search/views.py
+++ b/search/views.py
@@ -10,7 +10,7 @@ from django.utils.translation import gettext as _
 from django.views.decorators.http import require_POST
 
 from eventtracking import tracker as track
-from .api import perform_search, course_discovery_search, course_discovery_filter_fields
+from .api import perform_course_search, course_discovery_search, course_discovery_filter_fields
 from .initializer import SearchInitializer
 
 # log appears to be standard name used for logger
@@ -96,7 +96,7 @@ def do_search(request, course_id=None):
             }
         )
 
-        results = perform_search(
+        results = perform_course_search(
             search_term,
             user=request.user,
             size=size,


### PR DESCRIPTION
We need to know exactly what we are asking elasticsearch sometimes to debug problems. But we would prefer not to log it for all uses or force logging on openedx in general.

After a bunch of cleanup to make working in here a little easier and a new make target for local installation, I added a new log parameter to the general search arg and activates it for elasticsearch. Then I added a setting to turn this flag on for courseware search which is the place we currently need it, other settings can come later if desired.

After this is ready I'll add a default setting of False in platform lms and a devstack setting of True, and then some settings for edX proper in the internal settings repo to turn it on.

Sample local log
> 2023-11-15 21:24:56,566 INFO 107 [search.elastic] [user None] [ip 172.19.0.1] elastic.py:658 - full elastic search body {'query': {'bool': {'must': {'bool': {'must': [{'query_string': {'fields': ['content.*'], 'query': 'problem'}}, {'term': {'course': 'course-v1:edX+DemoX+Demo_Course'}}]}}, 'filter': {'bool': {'should': [{'range': {'start_date': {'lte': '2023-11-15T21:24:56.516152'}}}, {'bool': {'must_not': {'exists': {'field': 'start_date'}}}}]}}}}}