### PR TITLE
fix: cannot rename perform-search to clearer name, breaks tests

### DIFF
--- a/edxsearch/__init__.py
+++ b/edxsearch/__init__.py
@@ -1,3 +1,3 @@
 """ Container module for testing / demoing search """
 
-__version__ = '3.7.0'
+__version__ = '3.7.1'

--- a/search/api.py
+++ b/search/api.py
@@ -41,7 +41,7 @@ class NoSearchEngineError(Exception):
     """
 
 
-def perform_course_search(
+def perform_search(
         search_term,
         user=None,
         size=10,

--- a/search/tests/test_engines.py
+++ b/search/tests/test_engines.py
@@ -13,7 +13,7 @@ from django.test import TestCase
 from django.test.utils import override_settings
 from elasticsearch import exceptions
 from elasticsearch.helpers import BulkIndexError
-from search.api import NoSearchEngineError, perform_course_search
+from search.api import NoSearchEngineError, perform_search
 from search.elastic import RESERVED_CHARACTERS
 from search.tests.mock_search_engine import (MockSearchEngine,
                                              json_date_to_datetime)
@@ -238,7 +238,7 @@ class TestNone(TestCase):
     def test_perform_search(self):
         """ search opertaion should yeild an exception with no search engine """
         with self.assertRaises(NoSearchEngineError):
-            perform_course_search("abc test")
+            perform_search("abc test")
 
 
 @override_settings(SEARCH_ENGINE="search.elastic.ElasticSearchEngine")

--- a/search/views.py
+++ b/search/views.py
@@ -10,7 +10,7 @@ from django.utils.translation import gettext as _
 from django.views.decorators.http import require_POST
 
 from eventtracking import tracker as track
-from .api import perform_course_search, course_discovery_search, course_discovery_filter_fields
+from .api import perform_search, course_discovery_search, course_discovery_filter_fields
 from .initializer import SearchInitializer
 
 # log appears to be standard name used for logger
@@ -96,7 +96,7 @@ def do_search(request, course_id=None):
             }
         )
 
-        results = perform_course_search(
+        results = perform_search(
             search_term,
             user=request.user,
             size=size,


### PR DESCRIPTION
platform does not use this, but platform tests do, so the clarity is not worth the trouble and upgrade risk