### PR TITLE
docs: Add a long_description.

### DIFF
--- a/edxsearch/__init__.py
+++ b/edxsearch/__init__.py
@@ -1,3 +1,3 @@
 """ Container module for testing / demoing search """
 
-__version__ = '3.9.0'
+__version__ = '3.9.1'

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@
 """ Setup to allow pip installs of edx-search module """
 import os
 import re
+from pathlib import Path
 
 from setuptools import setup
 
@@ -47,11 +48,16 @@ def get_version(*file_paths):
 
 VERSION = get_version('edxsearch', '__init__.py')
 
+# read the contents of your README file
+this_directory = Path(__file__).parent
+long_description = (this_directory / "README.md").read_text()
 
 setup(
     name='edx-search',
     version=VERSION,
     description='Search and index routines for index access',
+    long_description=long_description,
+    long_description_content_type='text/markdown',
     author='edX',
     author_email='oscm@edx.org',
     url='https://github.com/openedx/edx-search',


### PR DESCRIPTION
The default empty long_description is failing so make the README the long_description.  Without this change new deploys to PyPI will fail.