### PR TITLE
feat: wait for meilisearch index creation to succeed

### DIFF
--- a/edxsearch/__init__.py
+++ b/edxsearch/__init__.py
@@ -1,3 +1,3 @@
 """ Container module for testing / demoing search """
 
-__version__ = '4.1.0'
+__version__ = '4.1.1'


### PR DESCRIPTION
In `search.meilisearch.create_indexes`, we were not waiting for the index creation tasks to complete. This was causing a potential race condition, where the `create_indexes` function would fail because it took a few seconds for the index creation to succeed.

See the relevant conversation here:
https://github.com/openedx/edx-platform/pull/35743#issuecomment-2450115310