### PR TITLE
fix: include catalog_visibility filter in courseware_content

### DIFF
--- a/search/meilisearch.py
+++ b/search/meilisearch.py
@@ -97,13 +97,14 @@ INDEX_FILTERABLES: dict[str, list[str]] = {
         "language",  # aggregate by language, mode, org
         "modes",
         "org",
-        "catalog_visibility",  # exclude visibility="none"
+        "catalog_visibility",  # used if not settings.SEARCH_SKIP_SHOW_IN_CATALOG_FILTERING
         "enrollment_end",  # include only enrollable courses
     ],
     getattr(settings, "COURSEWARE_CONTENT_INDEX_NAME", "courseware_content"): [
         PRIMARY_KEY_FIELD_NAME,  # exclude some specific documents based on ID
         "course",  # search courseware content by course
         "org",  # used during indexing
+        "catalog_visibility",  # used if not settings.SEARCH_SKIP_SHOW_IN_CATALOG_FILTERING
         "start_date",  # limit search to started courses
     ],
 }


### PR DESCRIPTION
The catalog_visibility filter is passed to the `courseware_content` index when performing a search using the legacy student dashboard view. If not included an error like follows is raised:

    MeilisearchApiError. Error code: invalid_search_filter. Error message:
    Attribute `catalog_visibility` is not filterable

I didn't dive to deep on this, but seems like the filter is added by the [`LmsSearchFilterGenerator`](https://github.com/openedx/edx-platform/blob/master/lms/lib/courseware_search/lms_filter_generator.py#L63-L66).

The normal course search in the Learning MFE doesn't throw any errors because the additional filters are not added when the search is [narrowed to a single course](https://github.com/openedx/edx-platform/blob/9cade7a3488eee24109311cb145747a01348df14/lms/lib/courseware_search/lms_filter_generator.py#L53-L54).

I'm not quite sure if this is the right approach considering that `catalog_visibility` doesn't appear in the documents for `courseware_content`, so the filter wouldn't really work.

I also noticed that if you configure the setting `SEARCH_SKIP_INVITATION_ONLY_FILTERING=False` you get `Unknown value type: <class 'bool'>` in both the dashboard search and the catalog search, because [`get_filter_rule`](https://github.com/openedx/edx-search/blob/15f34fbcb24afd96821a3a4a66889f9a66ce03c3/search/meilisearch.py/#L423) doesn't handle the bool case, and if it did we probably would get the filter error too.

## Testing instructions

On a tutor environment:

1. Because meilisearch is not included in nightly, I cherry-picked the meilisearch commit into the [nightly branch](https://github.com/eduNEXT/tutor/commit/817977f56a46b71b309d2f1851ddea662d71be01).
2. Created a small plugin to disable the learner-dashboard MFE:
    ```python
    from tutormfe.hooks import MFE_APPS
    
    @MFE_APPS.add()
    def _remove_mfes(mfes):
        mfes.pop("learner-dashboard")
        return mfes
    
    ```
3. Created a test course with a single 'Text' component with a sample search term 'exampleterm'
4. Search for 'exampleterm' on the dashboard search, it will throw _'An error occurred when searching for "exampleterm"'_
5. Use a an `edx-search` version with the fix and run `./manage.py lms shell -c "import search.meilisearch; search.meilisearch.create_indexes()"`
6. Repeat 4, this time the search should work.