### PR TITLE
chore: Add support for Django 5.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         python-version: ['3.11', '3.12']
-        toxenv: [django42, quality]
+        toxenv: [django42, django52, quality]
 
     steps:
     - uses: actions/checkout@v2
@@ -43,7 +43,7 @@ jobs:
       run: sleep 10 && tox
 
     - name: Run Coverage
-      if: matrix.python-version == '3.12' && matrix.toxenv=='django42'
+      if: matrix.python-version == '3.12' && matrix.toxenv=='django52'
       uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}

--- a/edxsearch/__init__.py
+++ b/edxsearch/__init__.py
@@ -1,3 +1,3 @@
 """ Container module for testing / demoing search """
 
-__version__ = '4.1.3'
+__version__ = '4.2.0'

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -10,13 +10,13 @@ annotated-types==0.7.0
     # via pydantic
 asgiref==3.8.1
     # via django
-attrs==25.1.0
+attrs==25.3.0
     # via openedx-events
 billiard==4.2.1
     # via celery
 camel-converter[pydantic]==4.0.1
     # via meilisearch
-celery==5.4.0
+celery==5.5.1
     # via event-tracking
 certifi==2025.1.31
     # via
@@ -40,9 +40,9 @@ click-plugins==1.1.1
     # via celery
 click-repl==0.3.0
     # via celery
-code-annotations==2.2.0
+code-annotations==2.3.0
     # via edx-toggles
-django==4.2.18
+django==4.2.20
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/base.in
@@ -64,16 +64,16 @@ dnspython==2.7.0
     # via pymongo
 edx-ccx-keys==2.0.2
     # via openedx-events
-edx-django-utils==7.1.0
+edx-django-utils==7.2.0
     # via
     #   edx-toggles
     #   event-tracking
     #   openedx-events
-edx-opaque-keys[django]==2.11.0
+edx-opaque-keys[django]==2.12.0
     # via
     #   edx-ccx-keys
     #   openedx-events
-edx-toggles==5.2.0
+edx-toggles==5.3.0
     # via
     #   -r requirements/base.in
     #   event-tracking
@@ -87,29 +87,29 @@ fastavro==1.10.0
     # via openedx-events
 idna==3.10
     # via requests
-jinja2==3.1.5
+jinja2==3.1.6
     # via code-annotations
-kombu==5.4.2
+kombu==5.5.2
     # via celery
 markupsafe==3.0.2
     # via jinja2
-meilisearch==0.33.1
+meilisearch==0.34.1
     # via -r requirements/base.in
-newrelic==10.5.0
+newrelic==10.8.1
     # via edx-django-utils
-openedx-events==9.17.0
+openedx-events==9.20.0
     # via event-tracking
-pbr==6.1.0
+pbr==6.1.1
     # via stevedore
 prompt-toolkit==3.0.50
     # via click-repl
-psutil==6.1.1
+psutil==7.0.0
     # via edx-django-utils
 pycparser==2.22
     # via cffi
-pydantic==2.10.6
+pydantic==2.11.3
     # via camel-converter
-pydantic-core==2.27.2
+pydantic-core==2.33.1
     # via pydantic
 pymongo==4.4.0
     # via
@@ -121,7 +121,7 @@ python-dateutil==2.9.0.post0
     # via celery
 python-slugify==8.0.4
     # via code-annotations
-pytz==2025.1
+pytz==2025.2
     # via event-tracking
 pyyaml==6.0.2
     # via code-annotations
@@ -134,22 +134,23 @@ six==1.17.0
     #   python-dateutil
 sqlparse==0.5.3
     # via django
-stevedore==5.4.0
+stevedore==5.4.1
     # via
     #   code-annotations
     #   edx-django-utils
     #   edx-opaque-keys
 text-unidecode==1.3
     # via python-slugify
-typing-extensions==4.12.2
+typing-extensions==4.13.1
     # via
     #   edx-opaque-keys
     #   pydantic
     #   pydantic-core
-tzdata==2025.1
-    # via
-    #   celery
-    #   kombu
+    #   typing-inspection
+typing-inspection==0.4.0
+    # via pydantic
+tzdata==2025.2
+    # via kombu
 urllib3==1.26.20
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
@@ -162,3 +163,6 @@ vine==5.1.0
     #   kombu
 wcwidth==0.2.13
     # via prompt-toolkit
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-cachetools==5.5.1
+cachetools==5.5.2
     # via tox
 chardet==5.2.0
     # via tox
@@ -12,7 +12,7 @@ colorama==0.4.6
     # via tox
 distlib==0.3.9
     # via virtualenv
-filelock==3.17.0
+filelock==3.18.0
     # via
     #   tox
     #   virtualenv
@@ -20,7 +20,7 @@ packaging==24.2
     # via
     #   pyproject-api
     #   tox
-platformdirs==4.3.6
+platformdirs==4.3.7
     # via
     #   tox
     #   virtualenv
@@ -28,7 +28,7 @@ pluggy==1.5.0
     # via tox
 pyproject-api==1.9.0
     # via tox
-tox==4.24.1
+tox==4.25.0
     # via -r requirements/ci.in
-virtualenv==20.29.1
+virtualenv==20.30.0
     # via tox

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -19,12 +19,12 @@ asgiref==3.8.1
     #   -r requirements/quality.txt
     #   -r requirements/testing.txt
     #   django
-astroid==3.3.8
+astroid==3.3.9
     # via
     #   -r requirements/quality.txt
     #   pylint
     #   pylint-celery
-attrs==25.1.0
+attrs==25.3.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/testing.txt
@@ -38,7 +38,7 @@ build==1.2.2.post1
     # via
     #   -r requirements/pip-tools.txt
     #   pip-tools
-cachetools==5.5.1
+cachetools==5.5.2
     # via
     #   -r requirements/ci.txt
     #   tox
@@ -47,7 +47,7 @@ camel-converter[pydantic]==4.0.1
     #   -r requirements/quality.txt
     #   -r requirements/testing.txt
     #   meilisearch
-celery==5.4.0
+celery==5.5.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/testing.txt
@@ -105,7 +105,7 @@ click-repl==0.3.0
     #   -r requirements/quality.txt
     #   -r requirements/testing.txt
     #   celery
-code-annotations==2.2.0
+code-annotations==2.3.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/testing.txt
@@ -115,7 +115,7 @@ colorama==0.4.6
     # via
     #   -r requirements/ci.txt
     #   tox
-coverage[toml]==7.6.10
+coverage[toml]==7.8.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/testing.txt
@@ -133,7 +133,7 @@ distlib==0.3.9
     # via
     #   -r requirements/ci.txt
     #   virtualenv
-django==4.2.18
+django==4.2.20
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/quality.txt
@@ -166,7 +166,7 @@ edx-ccx-keys==2.0.2
     #   -r requirements/quality.txt
     #   -r requirements/testing.txt
     #   openedx-events
-edx-django-utils==7.1.0
+edx-django-utils==7.2.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/testing.txt
@@ -175,13 +175,13 @@ edx-django-utils==7.1.0
     #   openedx-events
 edx-lint==5.6.0
     # via -r requirements/quality.txt
-edx-opaque-keys[django]==2.11.0
+edx-opaque-keys[django]==2.12.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/testing.txt
     #   edx-ccx-keys
     #   openedx-events
-edx-toggles==5.2.0
+edx-toggles==5.3.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/testing.txt
@@ -200,7 +200,7 @@ fastavro==1.10.0
     #   -r requirements/quality.txt
     #   -r requirements/testing.txt
     #   openedx-events
-filelock==3.17.0
+filelock==3.18.0
     # via
     #   -r requirements/ci.txt
     #   tox
@@ -210,21 +210,21 @@ idna==3.10
     #   -r requirements/quality.txt
     #   -r requirements/testing.txt
     #   requests
-iniconfig==2.0.0
+iniconfig==2.1.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/testing.txt
     #   pytest
-isort==6.0.0
+isort==6.0.1
     # via
     #   -r requirements/quality.txt
     #   pylint
-jinja2==3.1.5
+jinja2==3.1.6
     # via
     #   -r requirements/quality.txt
     #   -r requirements/testing.txt
     #   code-annotations
-kombu==5.4.2
+kombu==5.5.2
     # via
     #   -r requirements/quality.txt
     #   -r requirements/testing.txt
@@ -238,20 +238,20 @@ mccabe==0.7.0
     # via
     #   -r requirements/quality.txt
     #   pylint
-meilisearch==0.33.1
+meilisearch==0.34.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/testing.txt
-mock==5.1.0
+mock==5.2.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/testing.txt
-newrelic==10.5.0
+newrelic==10.8.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/testing.txt
     #   edx-django-utils
-openedx-events==9.17.0
+openedx-events==9.20.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/testing.txt
@@ -266,14 +266,14 @@ packaging==24.2
     #   pyproject-api
     #   pytest
     #   tox
-pbr==6.1.0
+pbr==6.1.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/testing.txt
     #   stevedore
 pip-tools==7.4.1
     # via -r requirements/pip-tools.txt
-platformdirs==4.3.6
+platformdirs==4.3.7
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
@@ -292,29 +292,29 @@ prompt-toolkit==3.0.50
     #   -r requirements/quality.txt
     #   -r requirements/testing.txt
     #   click-repl
-psutil==6.1.1
+psutil==7.0.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/testing.txt
     #   edx-django-utils
-pycodestyle==2.12.1
+pycodestyle==2.13.0
     # via -r requirements/quality.txt
 pycparser==2.22
     # via
     #   -r requirements/quality.txt
     #   -r requirements/testing.txt
     #   cffi
-pydantic==2.10.6
+pydantic==2.11.3
     # via
     #   -r requirements/quality.txt
     #   -r requirements/testing.txt
     #   camel-converter
-pydantic-core==2.27.2
+pydantic-core==2.33.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/testing.txt
     #   pydantic
-pylint==3.3.4
+pylint==3.3.6
     # via
     #   -r requirements/quality.txt
     #   edx-lint
@@ -354,12 +354,12 @@ pyproject-hooks==1.2.0
     #   -r requirements/pip-tools.txt
     #   build
     #   pip-tools
-pytest==8.3.4
+pytest==8.3.5
     # via
     #   -r requirements/quality.txt
     #   -r requirements/testing.txt
     #   pytest-cov
-pytest-cov==6.0.0
+pytest-cov==6.1.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/testing.txt
@@ -373,7 +373,7 @@ python-slugify==8.0.4
     #   -r requirements/quality.txt
     #   -r requirements/testing.txt
     #   code-annotations
-pytz==2025.1
+pytz==2025.2
     # via
     #   -r requirements/quality.txt
     #   -r requirements/testing.txt
@@ -401,7 +401,7 @@ sqlparse==0.5.3
     #   -r requirements/quality.txt
     #   -r requirements/testing.txt
     #   django
-stevedore==5.4.0
+stevedore==5.4.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/testing.txt
@@ -417,20 +417,25 @@ tomlkit==0.13.2
     # via
     #   -r requirements/quality.txt
     #   pylint
-tox==4.24.1
+tox==4.25.0
     # via -r requirements/ci.txt
-typing-extensions==4.12.2
+typing-extensions==4.13.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/testing.txt
     #   edx-opaque-keys
     #   pydantic
     #   pydantic-core
-tzdata==2025.1
+    #   typing-inspection
+typing-inspection==0.4.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/testing.txt
-    #   celery
+    #   pydantic
+tzdata==2025.2
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/testing.txt
     #   kombu
 urllib3==1.26.20
     # via
@@ -446,7 +451,7 @@ vine==5.1.0
     #   amqp
     #   celery
     #   kombu
-virtualenv==20.29.1
+virtualenv==20.30.0
     # via
     #   -r requirements/ci.txt
     #   tox

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -16,11 +16,11 @@ asgiref==3.8.1
     # via
     #   -r requirements/testing.txt
     #   django
-astroid==3.3.8
+astroid==3.3.9
     # via
     #   pylint
     #   pylint-celery
-attrs==25.1.0
+attrs==25.3.0
     # via
     #   -r requirements/testing.txt
     #   openedx-events
@@ -32,7 +32,7 @@ camel-converter[pydantic]==4.0.1
     # via
     #   -r requirements/testing.txt
     #   meilisearch
-celery==5.4.0
+celery==5.5.1
     # via
     #   -r requirements/testing.txt
     #   event-tracking
@@ -74,12 +74,12 @@ click-repl==0.3.0
     # via
     #   -r requirements/testing.txt
     #   celery
-code-annotations==2.2.0
+code-annotations==2.3.0
     # via
     #   -r requirements/testing.txt
     #   edx-lint
     #   edx-toggles
-coverage[toml]==7.6.10
+coverage[toml]==7.8.0
     # via
     #   -r requirements/quality.in
     #   -r requirements/testing.txt
@@ -90,7 +90,7 @@ ddt==1.3.1
     #   -r requirements/testing.txt
 dill==0.3.9
     # via pylint
-django==4.2.18
+django==4.2.20
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/testing.txt
@@ -118,7 +118,7 @@ edx-ccx-keys==2.0.2
     # via
     #   -r requirements/testing.txt
     #   openedx-events
-edx-django-utils==7.1.0
+edx-django-utils==7.2.0
     # via
     #   -r requirements/testing.txt
     #   edx-toggles
@@ -126,12 +126,12 @@ edx-django-utils==7.1.0
     #   openedx-events
 edx-lint==5.6.0
     # via -r requirements/quality.in
-edx-opaque-keys[django]==2.11.0
+edx-opaque-keys[django]==2.12.0
     # via
     #   -r requirements/testing.txt
     #   edx-ccx-keys
     #   openedx-events
-edx-toggles==5.2.0
+edx-toggles==5.3.0
     # via
     #   -r requirements/testing.txt
     #   event-tracking
@@ -149,17 +149,17 @@ idna==3.10
     # via
     #   -r requirements/testing.txt
     #   requests
-iniconfig==2.0.0
+iniconfig==2.1.0
     # via
     #   -r requirements/testing.txt
     #   pytest
-isort==6.0.0
+isort==6.0.1
     # via pylint
-jinja2==3.1.5
+jinja2==3.1.6
     # via
     #   -r requirements/testing.txt
     #   code-annotations
-kombu==5.4.2
+kombu==5.5.2
     # via
     #   -r requirements/testing.txt
     #   celery
@@ -169,15 +169,15 @@ markupsafe==3.0.2
     #   jinja2
 mccabe==0.7.0
     # via pylint
-meilisearch==0.33.1
+meilisearch==0.34.1
     # via -r requirements/testing.txt
-mock==5.1.0
+mock==5.2.0
     # via -r requirements/testing.txt
-newrelic==10.5.0
+newrelic==10.8.1
     # via
     #   -r requirements/testing.txt
     #   edx-django-utils
-openedx-events==9.17.0
+openedx-events==9.20.0
     # via
     #   -r requirements/testing.txt
     #   event-tracking
@@ -185,11 +185,11 @@ packaging==24.2
     # via
     #   -r requirements/testing.txt
     #   pytest
-pbr==6.1.0
+pbr==6.1.1
     # via
     #   -r requirements/testing.txt
     #   stevedore
-platformdirs==4.3.6
+platformdirs==4.3.7
     # via pylint
 pluggy==1.5.0
     # via
@@ -199,25 +199,25 @@ prompt-toolkit==3.0.50
     # via
     #   -r requirements/testing.txt
     #   click-repl
-psutil==6.1.1
+psutil==7.0.0
     # via
     #   -r requirements/testing.txt
     #   edx-django-utils
-pycodestyle==2.12.1
+pycodestyle==2.13.0
     # via -r requirements/quality.in
 pycparser==2.22
     # via
     #   -r requirements/testing.txt
     #   cffi
-pydantic==2.10.6
+pydantic==2.11.3
     # via
     #   -r requirements/testing.txt
     #   camel-converter
-pydantic-core==2.27.2
+pydantic-core==2.33.1
     # via
     #   -r requirements/testing.txt
     #   pydantic
-pylint==3.3.4
+pylint==3.3.6
     # via
     #   edx-lint
     #   pylint-celery
@@ -240,11 +240,11 @@ pynacl==1.5.0
     # via
     #   -r requirements/testing.txt
     #   edx-django-utils
-pytest==8.3.4
+pytest==8.3.5
     # via
     #   -r requirements/testing.txt
     #   pytest-cov
-pytest-cov==6.0.0
+pytest-cov==6.1.1
     # via -r requirements/testing.txt
 python-dateutil==2.9.0.post0
     # via
@@ -254,7 +254,7 @@ python-slugify==8.0.4
     # via
     #   -r requirements/testing.txt
     #   code-annotations
-pytz==2025.1
+pytz==2025.2
     # via
     #   -r requirements/testing.txt
     #   event-tracking
@@ -277,7 +277,7 @@ sqlparse==0.5.3
     # via
     #   -r requirements/testing.txt
     #   django
-stevedore==5.4.0
+stevedore==5.4.1
     # via
     #   -r requirements/testing.txt
     #   code-annotations
@@ -289,16 +289,20 @@ text-unidecode==1.3
     #   python-slugify
 tomlkit==0.13.2
     # via pylint
-typing-extensions==4.12.2
+typing-extensions==4.13.1
     # via
     #   -r requirements/testing.txt
     #   edx-opaque-keys
     #   pydantic
     #   pydantic-core
-tzdata==2025.1
+    #   typing-inspection
+typing-inspection==0.4.0
     # via
     #   -r requirements/testing.txt
-    #   celery
+    #   pydantic
+tzdata==2025.2
+    # via
+    #   -r requirements/testing.txt
     #   kombu
 urllib3==1.26.20
     # via
@@ -316,3 +320,6 @@ wcwidth==0.2.13
     # via
     #   -r requirements/testing.txt
     #   prompt-toolkit
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -16,7 +16,7 @@ asgiref==3.8.1
     # via
     #   -r requirements/base.txt
     #   django
-attrs==25.1.0
+attrs==25.3.0
     # via
     #   -r requirements/base.txt
     #   openedx-events
@@ -28,7 +28,7 @@ camel-converter[pydantic]==4.0.1
     # via
     #   -r requirements/base.txt
     #   meilisearch
-celery==5.4.0
+celery==5.5.1
     # via
     #   -r requirements/base.txt
     #   event-tracking
@@ -66,11 +66,11 @@ click-repl==0.3.0
     # via
     #   -r requirements/base.txt
     #   celery
-code-annotations==2.2.0
+code-annotations==2.3.0
     # via
     #   -r requirements/base.txt
     #   edx-toggles
-coverage[toml]==7.6.10
+coverage[toml]==7.8.0
     # via
     #   -r requirements/testing.in
     #   pytest-cov
@@ -105,18 +105,18 @@ edx-ccx-keys==2.0.2
     # via
     #   -r requirements/base.txt
     #   openedx-events
-edx-django-utils==7.1.0
+edx-django-utils==7.2.0
     # via
     #   -r requirements/base.txt
     #   edx-toggles
     #   event-tracking
     #   openedx-events
-edx-opaque-keys[django]==2.11.0
+edx-opaque-keys[django]==2.12.0
     # via
     #   -r requirements/base.txt
     #   edx-ccx-keys
     #   openedx-events
-edx-toggles==5.2.0
+edx-toggles==5.3.0
     # via
     #   -r requirements/base.txt
     #   event-tracking
@@ -134,13 +134,13 @@ idna==3.10
     # via
     #   -r requirements/base.txt
     #   requests
-iniconfig==2.0.0
+iniconfig==2.1.0
     # via pytest
-jinja2==3.1.5
+jinja2==3.1.6
     # via
     #   -r requirements/base.txt
     #   code-annotations
-kombu==5.4.2
+kombu==5.5.2
     # via
     #   -r requirements/base.txt
     #   celery
@@ -148,21 +148,21 @@ markupsafe==3.0.2
     # via
     #   -r requirements/base.txt
     #   jinja2
-meilisearch==0.33.1
+meilisearch==0.34.1
     # via -r requirements/base.txt
-mock==5.1.0
+mock==5.2.0
     # via -r requirements/testing.in
-newrelic==10.5.0
+newrelic==10.8.1
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
-openedx-events==9.17.0
+openedx-events==9.20.0
     # via
     #   -r requirements/base.txt
     #   event-tracking
 packaging==24.2
     # via pytest
-pbr==6.1.0
+pbr==6.1.1
     # via
     #   -r requirements/base.txt
     #   stevedore
@@ -172,7 +172,7 @@ prompt-toolkit==3.0.50
     # via
     #   -r requirements/base.txt
     #   click-repl
-psutil==6.1.1
+psutil==7.0.0
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
@@ -180,11 +180,11 @@ pycparser==2.22
     # via
     #   -r requirements/base.txt
     #   cffi
-pydantic==2.10.6
+pydantic==2.11.3
     # via
     #   -r requirements/base.txt
     #   camel-converter
-pydantic-core==2.27.2
+pydantic-core==2.33.1
     # via
     #   -r requirements/base.txt
     #   pydantic
@@ -197,9 +197,9 @@ pynacl==1.5.0
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
-pytest==8.3.4
+pytest==8.3.5
     # via pytest-cov
-pytest-cov==6.0.0
+pytest-cov==6.1.1
     # via -r requirements/testing.in
 python-dateutil==2.9.0.post0
     # via
@@ -209,7 +209,7 @@ python-slugify==8.0.4
     # via
     #   -r requirements/base.txt
     #   code-annotations
-pytz==2025.1
+pytz==2025.2
     # via
     #   -r requirements/base.txt
     #   event-tracking
@@ -231,7 +231,7 @@ sqlparse==0.5.3
     # via
     #   -r requirements/base.txt
     #   django
-stevedore==5.4.0
+stevedore==5.4.1
     # via
     #   -r requirements/base.txt
     #   code-annotations
@@ -241,16 +241,20 @@ text-unidecode==1.3
     # via
     #   -r requirements/base.txt
     #   python-slugify
-typing-extensions==4.12.2
+typing-extensions==4.13.1
     # via
     #   -r requirements/base.txt
     #   edx-opaque-keys
     #   pydantic
     #   pydantic-core
-tzdata==2025.1
+    #   typing-inspection
+typing-inspection==0.4.0
     # via
     #   -r requirements/base.txt
-    #   celery
+    #   pydantic
+tzdata==2025.2
+    # via
+    #   -r requirements/base.txt
     #   kombu
 urllib3==1.26.20
     # via
@@ -268,3 +272,6 @@ wcwidth==0.2.13
     # via
     #   -r requirements/base.txt
     #   prompt-toolkit
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools

--- a/setup.py
+++ b/setup.py
@@ -78,6 +78,7 @@ setup(
         'Framework :: Django :: 3.2',
         'Framework :: Django :: 4.0',
         'Framework :: Django :: 4.2',
+        'Framework :: Django :: 5.2',
     ],
     packages=['search', 'search.tests', 'edxsearch'],
     install_requires=load_requirements('requirements/base.in')

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@ deps =
     setuptools
     wheel
     django42: Django>=4.2,<4.3
+    django52: Django>=5.2,<5.3
     -r {toxinidir}/requirements/testing.txt
 commands =
     python -Wd -m coverage run manage.py test {posargs}


### PR DESCRIPTION
Closes:  #193 

Adds tox and CI testing support for Django 5.2. Also, ran upgrade for updating existing dependencies.