### PR TITLE
feat: [FC-86] add sorting feature for engines + enable_course_sorting_by_star…

### DIFF
--- a/search/api.py
+++ b/search/api.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from django.conf import settings
 
 from eventtracking import tracker as track
+from .dataclasses import FieldTypes, SortField
 from .filter_generator import SearchFilterGenerator
 from .search_engine_base import SearchEngine
 from .result_processor import SearchResultProcessor
@@ -122,12 +123,19 @@ def emit_api_timing_event(search_term, course_id, filter_generation_timer, proce
     })
 
 
-def course_discovery_search(search_term=None, size=20, from_=0, field_dictionary=None):
+def course_discovery_search(
+    search_term=None,
+    size=20,
+    from_=0,
+    field_dictionary=None,
+    enable_course_sorting_by_start_date=False,
+):
     """
     Course Discovery activities against the search engine index of course details
     """
     # We'll ignore the course-enrollemnt informaiton in field and filter
     # dictionary, and use our own logic upon enrollment dates for these
+    sort_by = None
     use_search_fields = ["org"]
     (search_fields, _, exclude_dictionary) = SearchFilterGenerator.generate_field_filters()
     use_field_dictionary = {
@@ -136,6 +144,8 @@ def course_discovery_search(search_term=None, size=20, from_=0, field_dictionary
     }
     if field_dictionary:
         use_field_dictionary.update(field_dictionary)
+    if enable_course_sorting_by_start_date:
+        sort_by = [SortField(name="start", type_=FieldTypes.DATETIME)]
     if not getattr(settings, "SEARCH_SKIP_ENROLLMENT_START_DATE_FILTERING", False):
         use_field_dictionary["enrollment_start"] = DateRange(None, datetime.utcnow())
 
@@ -155,6 +165,7 @@ def course_discovery_search(search_term=None, size=20, from_=0, field_dictionary
         filter_dictionary={"enrollment_end": DateRange(datetime.utcnow(), None)},
         exclude_dictionary=exclude_dictionary,
         aggregation_terms=course_discovery_aggregations(),
+        sort_by=sort_by,
     )
 
     return results

--- a/search/dataclasses.py
+++ b/search/dataclasses.py
@@ -23,5 +23,5 @@ class SortField:
     Represents a field used for sorting in search results.
     """
     name: str
-    type_: FieldTypes
+    type_: FieldTypes = FieldTypes.STRING
     order: Literal["asc", "desc"] = "asc"

--- a/search/dataclasses.py
+++ b/search/dataclasses.py
@@ -1,0 +1,27 @@
+"""
+Defines the dataclasses used in the search module.
+"""
+from dataclasses import dataclass
+from enum import Enum
+from typing import Literal
+
+
+class FieldTypes(Enum):
+    """
+    Enum for field types.
+    """
+    STRING = "string"
+    NUMBER = "number"
+    BOOLEAN = "boolean"
+    DATE = "date"
+    DATETIME = "datetime"
+
+
+@dataclass
+class SortField:
+    """
+    Represents a field used for sorting in search results.
+    """
+    name: str
+    type_: FieldTypes
+    order: Literal["asc", "desc"] = "asc"

--- a/search/meilisearch.py
+++ b/search/meilisearch.py
@@ -70,6 +70,7 @@ import meilisearch
 from django.conf import settings
 from django.utils import timezone
 
+from search.dataclasses import SortField
 from search.search_engine_base import SearchEngine
 from search.utils import ValueRange
 
@@ -109,6 +110,15 @@ INDEX_FILTERABLES: dict[str, list[str]] = {
     ],
 }
 
+INDEX_SORTABLES: dict[str, list[str]] = {
+    getattr(settings, "COURSEWARE_INFO_INDEX_NAME", "course_info"): [
+        "start",  # sort by start date
+    ],
+    getattr(settings, "COURSEWARE_CONTENT_INDEX_NAME", "courseware_content"): [
+        "start",  # sort by start date
+    ],
+}
+
 
 class MeilisearchEngine(SearchEngine):
     """
@@ -129,6 +139,7 @@ class MeilisearchEngine(SearchEngine):
             meilisearch_index_name = get_meilisearch_index_name(self.index_name)
             meilisearch_client = get_meilisearch_client()
             self._meilisearch_index = meilisearch_client.index(meilisearch_index_name)
+            self._meilisearch_index.update_sortable_attributes(INDEX_SORTABLES.get(self.index_name, []))
         return self._meilisearch_index
 
     @property
@@ -160,6 +171,7 @@ class MeilisearchEngine(SearchEngine):
         filter_dictionary=None,
         exclude_dictionary=None,
         aggregation_terms=None,
+        sort_by=None,
         # exclude_ids=None, # deprecated
         # use_field_match=False, # deprecated
         log_search_params=False,
@@ -173,6 +185,7 @@ class MeilisearchEngine(SearchEngine):
             filter_dictionary=filter_dictionary,
             exclude_dictionary=exclude_dictionary,
             aggregation_terms=aggregation_terms,
+            sort_by=self._transform_sort_by(sort_by) if sort_by else None,
             **kwargs,
         )
         if log_search_params:
@@ -195,6 +208,13 @@ class MeilisearchEngine(SearchEngine):
         doc_pks = [id2pk(doc_id) for doc_id in doc_ids]
         if doc_pks:
             self.meilisearch_index.delete_documents(doc_pks)
+
+    def transform_sort_by(self, fields: list[SortField]):
+        """
+        Helper function to transform sort_by dictionary to the format
+        expected by the search engine.
+        """
+        return [f"{field.name}:{field.order}" for field in fields]
 
 
 class DocumentEncoder(json.JSONEncoder):
@@ -368,6 +388,7 @@ def get_search_params(
     filter_dictionary=None,
     exclude_dictionary=None,
     aggregation_terms=None,
+    sort_by=None,
     **kwargs,
 ) -> dict[str, t.Any]:
     """
@@ -379,6 +400,10 @@ def get_search_params(
     # Aggregation
     if aggregation_terms:
         params["facets"] = list(aggregation_terms.keys())
+
+    # Sorting
+    if sort_by:
+        params["sort"] = sort_by
 
     # Exclusion and inclusion filters
     filters = []

--- a/search/meilisearch.py
+++ b/search/meilisearch.py
@@ -209,7 +209,7 @@ class MeilisearchEngine(SearchEngine):
         if doc_pks:
             self.meilisearch_index.delete_documents(doc_pks)
 
-    def transform_sort_by(self, fields: list[SortField]):
+    def _transform_sort_by(self, fields: list[SortField]):
         """
         Helper function to transform sort_by dictionary to the format
         expected by the search engine.

--- a/search/search_engine_base.py
+++ b/search/search_engine_base.py
@@ -4,6 +4,7 @@
 from waffle import switch_is_active  # lint-amnesty, pylint: disable=invalid-django-waffle-import
 from django.conf import settings
 
+from .dataclasses import SortField
 from .utils import _load_class
 
 # .. toggle_name: edx_search.default_elastic_search
@@ -42,12 +43,20 @@ class SearchEngine:
         """
         raise NotImplementedError
 
+    def _transform_sort_by(self, fields: list[SortField]):
+        """
+        Helper function to transform sort_by dictionary to the format
+        expected by the search engine.
+        """
+        return fields
+
     def search(self,
                query_string=None,
                field_dictionary=None,
                filter_dictionary=None,
                exclude_dictionary=None,
                aggregation_terms=None,
+               sort_by=None,
                log_search_params=False,
                **kwargs):  # pylint: disable=too-many-arguments
         """

--- a/search/tests/mock_search_engine.py
+++ b/search/tests/mock_search_engine.py
@@ -340,6 +340,7 @@ class MockSearchEngine(SearchEngine):
                filter_dictionary=None,
                exclude_dictionary=None,
                aggregation_terms=None,
+               sort_by=None,
                log_search_params=False,
                **kwargs):  # pylint: disable=too-many-arguments
         """
@@ -404,6 +405,13 @@ class MockSearchEngine(SearchEngine):
             kwargs["from_"] if "from_" in kwargs else None,
             sorted(search_results, key=lambda k: k["score"])
         )
+
+        if sort_by:
+            for field in sort_by:
+                results.sort(
+                    key=lambda x, sk=field: _find_field(x["data"], sk.name),
+                    reverse=field.order == "desc"
+                )
 
         response = {
             "took": 10,

--- a/search/tests/test_meilisearch.py
+++ b/search/tests/test_meilisearch.py
@@ -3,7 +3,7 @@ Test for the Meilisearch search engine.
 """
 
 from datetime import datetime
-from unittest.mock import Mock, patch
+from unittest.mock import Mock, patch, PropertyMock
 
 import django.test
 from django.utils import timezone
@@ -268,11 +268,17 @@ class EngineTests(django.test.TestCase):
             "enrollment_end >= 1704067200.0 OR enrollment_end NOT EXISTS"
         ] == params["filter"]
 
-    def test_engine_init(self):
+    @patch('search.meilisearch.MeilisearchEngine.meilisearch_index', new_callable=PropertyMock)
+    def test_engine_init(self, mock_meilisearch_index):
+        mock_index = Mock()
+        mock_meilisearch_index.return_value = mock_index
         engine = search.meilisearch.MeilisearchEngine(index="my_index")
-        assert engine.meilisearch_index_name == "my_index"
+        assert engine.index_name == "my_index"
 
-    def test_engine_index(self):
+    @patch('search.meilisearch.MeilisearchEngine.meilisearch_index', new_callable=PropertyMock)
+    def test_engine_index(self, mock_meilisearch_index):
+        mock_index = Mock()
+        mock_meilisearch_index.return_value = mock_index
         engine = search.meilisearch.MeilisearchEngine(index="my_index")
         engine.meilisearch_index.add_documents = Mock()
         document = {
@@ -294,24 +300,26 @@ class EngineTests(django.test.TestCase):
             serializer=search.meilisearch.DocumentEncoder,
         )
 
-    def test_engine_search(self):
+    @patch('search.meilisearch.MeilisearchEngine.meilisearch_index', new_callable=PropertyMock)
+    def test_engine_search(self, mock_meilisearch_index):
+        mock_index = Mock()
+        mock_meilisearch_index.return_value = mock_index
+
         engine = search.meilisearch.MeilisearchEngine(index="my_index")
-        engine.meilisearch_index.search = Mock(
-            return_value={
-                "hits": [
-                    {
-                        "pk": "f381d4f1914235c9532576c0861d09b484ade634",
-                        "id": "course-v1:OpenedX+DemoX+DemoCourse",
-                        "_rankingScore": 0.865,
-                    },
-                ],
-                "query": "demo",
-                "processingTimeMs": 0,
-                "limit": 20,
-                "offset": 0,
-                "estimatedTotalHits": 1,
-            }
-        )
+        mock_index.search.return_value = {
+            "hits": [
+                {
+                    "pk": "f381d4f1914235c9532576c0861d09b484ade634",
+                    "id": "course-v1:OpenedX+DemoX+DemoCourse",
+                    "_rankingScore": 0.865,
+                },
+            ],
+            "query": "demo",
+            "processingTimeMs": 0,
+            "limit": 20,
+            "offset": 0,
+            "estimatedTotalHits": 1,
+        }
 
         results = engine.search(
             query_string="abc",
@@ -356,9 +364,12 @@ class EngineTests(django.test.TestCase):
             "total": 1,
         }
 
-    def test_engine_remove(self):
+    @patch('search.meilisearch.MeilisearchEngine.meilisearch_index', new_callable=PropertyMock)
+    def test_engine_remove(self, mock_meilisearch_index):
+        mock_index = Mock()
+        mock_meilisearch_index.return_value = mock_index
         engine = search.meilisearch.MeilisearchEngine(index="my_index")
-        engine.meilisearch_index.delete_documents = Mock()
+        mock_index.delete_documents = Mock()
         # Primary key field
         # can be verified with: echo -n "abcd" | sha1sum
         doc_id = "abcd"

--- a/search/tests/test_mock_search_engine.py
+++ b/search/tests/test_mock_search_engine.py
@@ -6,6 +6,7 @@ import pytz
 from django.test import TestCase
 from django.test.utils import override_settings
 
+from search.search_engine_base import SearchEngine
 from search.tests.mock_search_engine import _find_field, _filter_intersection, json_date_to_datetime
 from search.tests.utils import SearcherMixin
 from search.utils import DateRange
@@ -125,3 +126,26 @@ class MockSpecificSearchTests(TestCase, SearcherMixin):
 
         response = self.searcher.search(field_dictionary={"start_date": DateRange(datetime(2099, 1, 1), None)})
         self.assertEqual(response["total"], 1)
+
+
+class SearchEngineBaseTests(TestCase):
+    """
+    Tests for the SearchEngine base class.
+    """
+
+    def setUp(self):
+        """
+        Set up the SearchEngine instance for testing.
+        """
+        self.searcher = SearchEngine()
+
+    def test_search_engine_base_transform_sort_by(self):
+        """
+        Test that the transform_sort_by method returns the fields as is.
+        """
+        fields = [
+            {"field": "title", "direction": "asc"},
+            {"field": "date", "direction": "desc"}
+        ]
+        transformed_fields = self.searcher._transform_sort_by(fields)  # pylint: disable=protected-access
+        self.assertEqual(transformed_fields, fields)

--- a/search/views.py
+++ b/search/views.py
@@ -166,6 +166,7 @@ def course_discovery(request):
     status_code = 500
 
     search_term = request.POST.get("search_string", None)
+    enable_course_sorting_by_start_date = request.POST.get("enable_course_sorting_by_start_date", False)
 
     try:
         size, from_, page = _process_pagination_values(request)
@@ -186,6 +187,7 @@ def course_discovery(request):
             size=size,
             from_=from_,
             field_dictionary=field_dictionary,
+            enable_course_sorting_by_start_date=enable_course_sorting_by_start_date,
         )
 
         # Analytics - log search results before sending to browser

--- a/search/views.py
+++ b/search/views.py
@@ -159,6 +159,7 @@ def course_discovery(request):
         "search_string" (optional) - text with which to search for courses
         "page_size" (optional)- how many results to return per page (defaults to 20, with maximum cutoff at 100)
         "page_index" (optional) - for which page (zero-indexed) to include results (defaults to 0)
+        "enable_course_sorting_by_start_date" (optional) - boolean to enable sorting by start date
     """
     results = {
         "error": _("Nothing to search")


### PR DESCRIPTION
# Add Sorting Feature for Engines + `enable_course_sorting_by_start_date` Parameter

This PR introduces a sorting feature for search engines and adds a new parameter, `enable_course_sorting_by_start_date`, to the course discovery search.

**Key changes:**

- Adds `enable_course_sorting_by_start_date` to the course discovery search API, allowing results to be sorted by course start date when enabled.
- Implements a generic `SortField` dataclass and `FieldTypes` enum to support flexible sorting across different search engines.
- Updates ElasticSearch, Meilisearch, and mock search engine backends to support sorting via the `sort_by` parameter.
- Ensures Meilisearch index is configured with `start` as a sortable field.
- Updates the course discovery view to accept and forward the new sorting parameter.
- Adds comprehensive tests verifying sorting behavior by course start date.

These changes allow consumers to opt into sorting course results by start date, enabling richer search and browsing experiences across all supported backends.
