### PR TITLE
feat: [AXM-2518] implement multivalue faceted search using Meilisearch

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,22 @@ services:
     ports:
       - "9200:9200"
 
+  test_meilisearch:
+    image: getmeili/meilisearch:v1.7
+    container_name: test_meilisearch
+    ports:
+      - "7700:7700"
+    environment:
+      MEILISEARCH_MASTER_KEY: test_master_key
+      MEILISEARCH_URL: http://localhost:7700
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:7700/health"]
+      interval: 2s
+      timeout: 1s
+      retries: 10
+
+version: '3.8'
+
 volumes:
   data01:
     driver: local

--- a/edxsearch/settings.py
+++ b/edxsearch/settings.py
@@ -128,3 +128,6 @@ EVENT_TRACKING_BACKENDS = {
         }
     }
 }
+
+MEILISEARCH_API_KEY=os.environ.get("MEILISEARCH_MASTER_KEY", "test_master_key")
+MEILISEARCH_URL=os.environ.get("MEILISEARCH_URL", "http://meilisearch")

--- a/search/api.py
+++ b/search/api.py
@@ -122,7 +122,7 @@ def emit_api_timing_event(search_term, course_id, filter_generation_timer, proce
     })
 
 
-def course_discovery_search(search_term=None, size=20, from_=0, field_dictionary=None):
+def course_discovery_search(search_term=None, size=20, from_=0, field_dictionary=None, is_multivalue=False):
     """
     Course Discovery activities against the search engine index of course details
     """
@@ -155,6 +155,7 @@ def course_discovery_search(search_term=None, size=20, from_=0, field_dictionary
         filter_dictionary={"enrollment_end": DateRange(datetime.utcnow(), None)},
         exclude_dictionary=exclude_dictionary,
         aggregation_terms=course_discovery_aggregations(),
+        is_multivalue=is_multivalue,
     )
 
     return results

--- a/search/meilisearch.py
+++ b/search/meilisearch.py
@@ -70,6 +70,7 @@ import meilisearch
 from django.conf import settings
 from django.utils import timezone
 
+from search.api import course_discovery_filter_fields
 from search.search_engine_base import SearchEngine
 from search.utils import ValueRange
 
@@ -168,6 +169,7 @@ class MeilisearchEngine(SearchEngine):
         """
         See meilisearch docs: https://www.meilisearch.com/docs/reference/api/search
         """
+        is_multivalue = kwargs.pop("is_multivalue", False)
         opt_params = get_search_params(
             field_dictionary=field_dictionary,
             filter_dictionary=filter_dictionary,
@@ -178,8 +180,36 @@ class MeilisearchEngine(SearchEngine):
         if log_search_params:
             logger.info("Search query: opt_params=%s", opt_params)
         meilisearch_results = self.meilisearch_index.search(query_string, opt_params)
-        processed_results = process_results(meilisearch_results, self.index_name)
-        return processed_results
+
+        if is_multivalue:
+            self._expand_facet_distibutions(field_dictionary, query_string, opt_params, meilisearch_results)
+
+        return process_results(meilisearch_results, self.index_name)
+
+    def _expand_facet_distibutions(self, field_dictionary, query_string, opt_params, meilisearch_results):
+        """
+        For each selected facet, get all its available options within the selected filters.
+        """
+        for facet in field_dictionary.keys():
+            expanded_facet_distribution = self._get_expanded_distribution(
+                query_string,
+                facet,
+                opt_params.get("filter", []),
+            )
+            meilisearch_results.setdefault("facetDistribution", {})[facet] = expanded_facet_distribution
+
+    def _get_expanded_distribution(self, query, facet_to_exclude, filter_rules):
+        """
+        Run a secondary query excluding one facet to get its full distribution.
+        Only return distribution data, without any actual results.
+        """
+        secondary_opt_params = {
+            'facets': [facet_to_exclude],
+            'filter': [rule for rule in filter_rules if not rule.startswith(f"{facet_to_exclude} = ")],
+            'limit': 0,
+        }
+        result = self.meilisearch_index.search(query, secondary_opt_params)
+        return result.get("facetDistribution", {}).get(facet_to_exclude, {})
 
     def remove(self, doc_ids, **kwargs):
         """
@@ -407,16 +437,20 @@ def get_filter_rules(
     Convert inclusion/exclusion rules.
     """
     rules = []
-    for key, value in rule_dict.items():
-        if isinstance(value, list):
-            for v in value:
-                rules.append(
-                    get_filter_rule(key, v, exclude=exclude, optional=optional)
-                )
+    filter_fields = course_discovery_filter_fields()
+    for rule_name, rule_value in rule_dict.items():
+        if isinstance(rule_value, list):
+            if rule_name in filter_fields:
+                rules.append(" OR ".join(f'{rule_name} = "{nested_value}"' for nested_value in rule_value))
+            else:
+                rules += [
+                    get_filter_rule(
+                        rule_name, nested_value, exclude=exclude, optional=optional
+                    ) for nested_value in rule_value
+                ]
         else:
-            rules.append(
-                get_filter_rule(key, value, exclude=exclude, optional=optional)
-            )
+            rules.append(get_filter_rule(rule_name, rule_value, exclude=exclude, optional=optional))
+
     return rules
 
 

--- a/search/tests/test_course_discovery.py
+++ b/search/tests/test_course_discovery.py
@@ -4,8 +4,10 @@
 """ Tests for search functionalty """
 
 import copy
+import time
 from datetime import datetime
 import ddt
+import meilisearch
 
 from django.core.cache import cache
 from django.test import TestCase
@@ -16,6 +18,7 @@ from search.api import course_discovery_search, NoSearchEngineError
 from search.elastic import ElasticSearchEngine
 from search.tests.utils import SearcherMixin, TEST_INDEX_NAME
 from .mock_search_engine import MockSearchEngine
+from search.meilisearch import get_meilisearch_client, create_indexes
 
 
 class DemoCourse:
@@ -372,3 +375,288 @@ class TestNone(TestCase):
         """ search opertaion should yeild an exception with no search engine """
         with self.assertRaises(NoSearchEngineError):
             course_discovery_search("abc test")
+
+
+@override_settings(SEARCH_ENGINE="search.meilisearch.MeilisearchEngine")
+@override_settings(COURSEWARE_INFO_INDEX_NAME=TEST_INDEX_NAME)
+class TestMeilisearchCourseDiscoverySearch(TestCase, SearcherMixin):
+    """
+    Integration tests using real Meilisearch engine.
+    """
+
+    def setUp(self):
+        super().setUp()
+        create_indexes({TEST_INDEX_NAME: [
+            "language",
+            "modes",
+            "org",
+            "catalog_visibility",
+            "enrollment_start",
+            "enrollment_end",
+        ]})
+        self.wait_for_meilisearch_indexing()
+
+    def tearDown(self):
+        client = get_meilisearch_client()
+        try:
+            client.index(TEST_INDEX_NAME).delete()
+        except meilisearch.errors.MeilisearchApiError:
+            pass
+        super().tearDown()
+
+    @staticmethod
+    def wait_for_meilisearch_indexing():
+        from search.meilisearch import get_meilisearch_client
+        client = get_meilisearch_client()
+        task = client.index(TEST_INDEX_NAME).get_tasks().results[-1]
+        if not task:
+            return
+        client.wait_for_task(task.uid)
+        time.sleep(0.2)
+
+    def test_course_matching_empty_index(self):
+        """ Check for empty result count before indexing """
+        results = course_discovery_search("defensive")
+        self.assertEqual(results["total"], 0)
+
+    def test_course_matching(self):
+        """ Make sure that matches within content can be located and processed """
+        DemoCourse.get_and_index(self.searcher, {
+            "content": {
+                "short_description": "This is a defensive move",
+                "overview": "Defensive teams often win"
+            }
+        })
+        self.wait_for_meilisearch_indexing()
+
+        DemoCourse.get_and_index(self.searcher, {
+            "content": {
+                "short_description": "This is an offensive move",
+                "overview": "Offensive teams often win"
+            }
+        })
+        self.wait_for_meilisearch_indexing()
+
+        DemoCourse.get_and_index(self.searcher, {
+            "content": {
+                "short_description": "This is a hyphenated move",
+                "overview": "Highly-offensive teams often win"
+            }
+        })
+        self.wait_for_meilisearch_indexing()
+
+        results = course_discovery_search()
+        self.assertEqual(results["total"], 3)
+
+    @override_settings(COURSE_DISCOVERY_AGGREGATIONS={"subject": {}, "lang": {}})
+    def test_aggregating_override(self):
+        """
+        Test that aggregation under consideration can be specified
+        with custom setting
+        """
+        create_indexes({TEST_INDEX_NAME: [
+            "lang",
+            "subject",
+        ]})
+
+        DemoCourse.get_and_index(self.searcher, {"subject": "Mathematics", "lang": ["en", "fr"]})
+        DemoCourse.get_and_index(self.searcher, {"subject": "Mathematics", "lang": ["en"]})
+        DemoCourse.get_and_index(self.searcher, {"subject": "History", "lang": ["en"]})
+        DemoCourse.get_and_index(self.searcher, {"subject": "History", "lang": ["fr"]})
+        DemoCourse.get_and_index(self.searcher, {"lang": ["de"]})
+        self.wait_for_meilisearch_indexing()
+
+        results = course_discovery_search()
+        self.assertEqual(results["total"], 5)
+        self.assertIn("aggs", results)
+
+        self.assertNotIn("org", results["aggs"])
+        self.assertNotIn("modes", results["aggs"])
+
+        self.assertIn("subject", results["aggs"])
+        self.assertEqual(results["aggs"]["subject"]["total"], 4)
+        self.assertEqual(results["aggs"]["subject"]["terms"]["Mathematics"], 2)
+        self.assertEqual(results["aggs"]["subject"]["terms"]["History"], 2)
+
+        self.assertIn("lang", results["aggs"])
+        self.assertEqual(results["aggs"]["lang"]["total"], 6)
+        self.assertEqual(results["aggs"]["lang"]["terms"]["en"], 3)
+        self.assertEqual(results["aggs"]["lang"]["terms"]["fr"], 2)
+        self.assertEqual(results["aggs"]["lang"]["terms"]["de"], 1)
+
+    def test_course_list(self):
+        """ No arguments to course_discovery_search should show all available courses"""
+        results = course_discovery_search()
+        self.assertEqual(results["total"], 0)
+
+        DemoCourse.get_and_index(self.searcher)
+        self.wait_for_meilisearch_indexing()
+        results = course_discovery_search()
+        self.assertEqual(results["total"], 1)
+
+    def test_discovery_field_matching(self):
+        """ Test that field specifications only show those results with the desired field values """
+        DemoCourse.get_and_index(self.searcher, {"org": "OrgA"})
+        DemoCourse.get_and_index(self.searcher, {"org": "OrgB"})
+        self.wait_for_meilisearch_indexing()
+
+        results = course_discovery_search()
+        self.assertEqual(results["total"], 2)
+
+        results = course_discovery_search(field_dictionary={"org": "OrgA"})
+        self.assertEqual(results["total"], 1)
+        self.assertEqual(results["results"][0]["data"]["org"], "OrgA")
+
+        results = course_discovery_search(field_dictionary={"org": "OrgB"})
+        self.assertEqual(results["total"], 1)
+        self.assertEqual(results["results"][0]["data"]["org"], "OrgB")
+
+    def test_multivalue_field_matching(self):
+        """
+        Test that field specifications only show those results with the desired
+        field values - even when there is an array of possible values
+        """
+        DemoCourse.get_and_index(self.searcher, {"modes": ["honor", "verified"]})
+        DemoCourse.get_and_index(self.searcher, {"modes": ["honor"]})
+        self.wait_for_meilisearch_indexing()
+
+        results = course_discovery_search()
+        self.assertEqual(results["total"], 2)
+
+        results = course_discovery_search(field_dictionary={"modes": "honor"})
+        self.assertEqual(results["total"], 2)
+
+        results = course_discovery_search(field_dictionary={"modes": "verified"})
+        self.assertEqual(results["total"], 1)
+
+    def test_enroll_date(self):
+        """
+        Test that we don't show any courses that have no published enrollment date, or an enrollment date in the future
+        """
+        # demo_course_1 should be found cos it has a date that is valid
+        DemoCourse.get_and_index(self.searcher, {"enrollment_start": datetime(2014, 1, 1)})
+
+        # demo_course_2 should not be found because it has enrollment_start date set explicitly to None
+        DemoCourse.get_and_index(self.searcher, {"enrollment_start": None})
+
+        # demo_course_3 should not be found because it has enrollment_start date in the future
+        DemoCourse.get_and_index(self.searcher, {"enrollment_start": datetime(2114, 1, 1)})
+
+        # demo_course_4 should not be found because it has no enrollment_start specification
+        DemoCourse.get_and_index(self.searcher, {}, ["enrollment_start"])
+
+        self.wait_for_meilisearch_indexing()
+
+        results = course_discovery_search()
+        self.assertEqual(results["total"], 1)
+
+        additional_course = DemoCourse.get()
+        DemoCourse.index(self.searcher, [additional_course])
+        self.wait_for_meilisearch_indexing()
+
+        results = course_discovery_search()
+        self.assertEqual(results["total"], 2)
+
+        # Mark the course as having ended enrollment
+        additional_course["enrollment_end"] = datetime(2015, 1, 1)
+        DemoCourse.index(self.searcher, [additional_course])
+        self.wait_for_meilisearch_indexing()
+
+        results = course_discovery_search()
+        self.assertEqual(results["total"], 1)
+
+    def test_aggregating(self):
+        DemoCourse.get_and_index(self.searcher, {"language": "en", "org": "EDX"})
+        self.wait_for_meilisearch_indexing()
+
+        DemoCourse.get_and_index(self.searcher, {"language": "fr", "org": "ORG2"})
+        self.wait_for_meilisearch_indexing()
+
+        results = course_discovery_search(
+            search_term="",
+            field_dictionary={"language": ["en"]},
+            is_multivalue=True
+        )
+        self.assertDictEqual(results["aggs"]["language"]["terms"], {"en": 1, "fr": 1})
+        self.assertDictEqual(results["aggs"]["org"]["terms"], {"EDX": 1})
+
+    def test_aggregating_with_single_values_in_two_facets(self):
+        DemoCourse.get_and_index(self.searcher, {
+            "language": "en",
+            "org": "EDX",
+            "modes": "audit",
+        })
+        self.wait_for_meilisearch_indexing()
+
+        DemoCourse.get_and_index(self.searcher, {
+            "language": "en",
+            "org": "ORG2",
+            "modes": "honor",
+        })
+        self.wait_for_meilisearch_indexing()
+
+        results = course_discovery_search(
+            search_term="",
+            field_dictionary={"language": "en", "org": "EDX"}
+        )
+
+        self.assertIn("audit", results["aggs"]["modes"]["terms"])
+        self.assertNotIn("honor", results["aggs"]["modes"]["terms"])
+        self.assertEqual(results["aggs"]["language"]["terms"], {"en": 1})
+        self.assertEqual(results["aggs"]["org"]["terms"], {"EDX": 1})
+
+    def test_aggregating_with_multi_value_facet(self):
+        DemoCourse.get_and_index(self.searcher, {
+            "org": "EDX",
+            "language": "en",
+            "modes": "audit",
+        })
+        self.wait_for_meilisearch_indexing()
+
+        DemoCourse.get_and_index(self.searcher, {
+            "org": "EDX",
+            "language": "fr",
+            "modes": "honor",
+        })
+        self.wait_for_meilisearch_indexing()
+
+        DemoCourse.get_and_index(self.searcher, {
+            "org": "ORG2",
+            "language": "uk",
+            "modes": "verified",
+        })
+        self.wait_for_meilisearch_indexing()
+
+        results = course_discovery_search(
+            search_term="",
+            field_dictionary={"language": ["en", "fr"]},
+            is_multivalue=True
+        )
+
+        aggregations = results["aggs"]
+        self.assertIn("en", aggregations["language"]["terms"])
+        self.assertIn("fr", aggregations["language"]["terms"])
+        self.assertIn("uk", aggregations["language"]["terms"])
+        self.assertDictEqual(aggregations["language"]["terms"], {"en": 1, "fr": 1, "uk": 1})
+
+        self.assertNotIn("verified", aggregations["modes"]["terms"])
+        self.assertDictEqual(aggregations["modes"]["terms"], {"audit": 1, "honor": 1})
+
+        self.assertNotIn("ORG2", aggregations["org"]["terms"])
+        self.assertDictEqual(aggregations["org"]["terms"], {"EDX": 2})
+
+    def test_aggregating_facet_narrowed_if_single_value_search(self):
+        DemoCourse.get_and_index(self.searcher, {"language": "en", "modes": "audit"})
+        self.wait_for_meilisearch_indexing()
+
+        DemoCourse.get_and_index(self.searcher, {"language": "en", "modes": "honor"})
+        self.wait_for_meilisearch_indexing()
+
+        results = course_discovery_search(
+            search_term="",
+            field_dictionary={"modes": ["honor"]},
+            is_multivalue=False
+        )
+
+        self.assertNotIn("audit", results["aggs"]["modes"]["terms"])
+        self.assertDictEqual(results["aggs"]["modes"]["terms"], {'honor': 1})

--- a/search/tests/test_meilisearch.py
+++ b/search/tests/test_meilisearch.py
@@ -3,7 +3,7 @@ Test for the Meilisearch search engine.
 """
 
 from datetime import datetime
-from unittest.mock import Mock, patch
+from unittest.mock import Mock, patch, MagicMock
 
 import django.test
 from django.utils import timezone
@@ -313,7 +313,7 @@ class EngineTests(django.test.TestCase):
             }
         )
 
-        results = engine.search(
+        result = engine.search(
             query_string="abc",
             field_dictionary={
                 "course": "course-v1:testorg+test1+alpha",
@@ -325,7 +325,7 @@ class EngineTests(django.test.TestCase):
             log_search_params=True,
         )
 
-        engine.meilisearch_index.search.assert_called_with(
+        engine.meilisearch_index.search.assert_called_once_with(
             "abc",
             {
                 "showRankingScore": True,
@@ -338,10 +338,12 @@ class EngineTests(django.test.TestCase):
                 ],
             },
         )
-        assert results == {
-            "aggs": {},
-            "max_score": 0.865,
-            "results": [
+        self.assertEqual(result["max_score"], 0.865)
+        self.assertEqual(result["took"], 0)
+        self.assertEqual(result["total"], 1)
+        self.assertListEqual(
+            result["results"],
+            [
                 {
                     "_id": "course-v1:OpenedX+DemoX+DemoCourse",
                     "_index": "my_index",
@@ -351,10 +353,8 @@ class EngineTests(django.test.TestCase):
                         "pk": "f381d4f1914235c9532576c0861d09b484ade634",
                     },
                 },
-            ],
-            "took": 0,
-            "total": 1,
-        }
+            ]
+        )
 
     def test_engine_remove(self):
         engine = search.meilisearch.MeilisearchEngine(index="my_index")
@@ -365,6 +365,148 @@ class EngineTests(django.test.TestCase):
         doc_pk = "81fe8bfe87576c3ecb22426f8e57847382917acf"
         engine.remove(doc_ids=[doc_id])
         engine.meilisearch_index.delete_documents.assert_called_with([doc_pk])
+
+    def test_multivalue_search_uses_or_to_join_rules_within_facet(self):
+        filter_dict = {
+            "language": ["en", "fr"]
+        }
+        rules = search.meilisearch.get_filter_rules(filter_dict)
+
+        self.assertListEqual(rules, ['language = "en" OR language = "fr"'])
+
+    def test_multivalue_search_expands_selected_facet_without_filtering(self):
+        multivalue_distribution = {'en': 1, 'fr': 2}
+
+        engine = search.meilisearch.MeilisearchEngine(index="test_index")
+        engine.meilisearch_index.search = Mock(
+            return_value={
+                'hits': [],
+                'query': '',
+                'processingTimeMs': 0,
+                'limit': 0,
+                'offset': 0,
+                'estimatedTotalHits': 4,
+                'facetDistribution':
+                    {'language': multivalue_distribution},
+                'facetStats': {}
+            }
+        )
+
+        original_filter = [
+            'language = "en" OR language = "fr"',
+            'modes = "audit" OR modes = "honor"',
+            'org = "EDX"',
+        ]
+        selected_facet = 'language'
+        actual_distribution = engine._get_expanded_distribution(
+            '', selected_facet, original_filter
+        )
+        self.assertDictEqual(actual_distribution, multivalue_distribution)
+        (query, opt_params), _ = engine.meilisearch_index.search.call_args
+        self.assertIn(selected_facet, opt_params['facets'])
+        self.assertFalse(any(rule.startswith(f'{selected_facet} = ') for rule in opt_params['filter']))
+
+    def test_multivalue_search_merges_expanded_facet_distributions(self):
+        engine = search.meilisearch.MeilisearchEngine(index='test_index')
+        engine.meilisearch_index.search = Mock(side_effect=[
+            {
+                "hits": [],
+                "query": "",
+                "processingTimeMs": 5,
+                "limit": 20,
+                "offset": 0,
+                "estimatedTotalHits": 0,
+                "facetDistribution": {
+                    "language": {"en": 2},  # Narrowed distribution after selecting a facet value
+                    "org": {"EDX": 2}
+                },
+            },
+            {
+                "hits": [],
+                "facetDistribution": {
+                    "language": {"en": 2, "fr": 1}  # Expanded distribution for multivalue search
+                }
+            }
+        ])
+
+        results = engine.search(
+            query_string='',
+            field_dictionary={'language': ['en']},
+            is_multivalue=True,
+        )
+        aggregations = results["aggs"]
+        self.assertIn("language", aggregations)
+        self.assertIn("org", aggregations)
+        self.assertDictEqual(
+            aggregations["language"]["terms"],
+            {"en": 2, "fr": 1}
+        )
+        self.assertDictEqual(aggregations["org"]["terms"], {"EDX": 2})
+
+    def test_single_value_search_narrows_selected_facet(self):
+        engine = search.meilisearch.MeilisearchEngine(index='test_index')
+        engine.meilisearch_index.search = Mock(side_effect=[
+            {
+                "hits": [],
+                "query": "",
+                "processingTimeMs": 5,
+                "limit": 20,
+                "offset": 0,
+                "estimatedTotalHits": 0,
+                "facetDistribution": {
+                    "language": {"en": 2},
+                    "org": {"EDX": 2}
+                },
+            },
+            {
+                "hits": [],
+                "facetDistribution": {
+                    "language": {"en": 2, "fr": 1}
+                }
+            }
+        ])
+
+        results = engine.search(
+            query_string='',
+            field_dictionary={'language': ['en']},
+            is_multivalue=False,
+        )
+        aggregations = results["aggs"]
+        self.assertIn("language", aggregations)
+        self.assertIn("org", aggregations)
+        self.assertDictEqual(
+            aggregations["language"]["terms"],
+            {"en": 2}
+        )
+        self.assertDictEqual(aggregations["org"]["terms"], {"EDX": 2})
+
+    def test_facet_expansion_not_triggered_if_not_multivalue(self):
+        engine = search.meilisearch.MeilisearchEngine(index="test_index")
+        engine._expand_facet_distibutions = MagicMock()
+        engine.meilisearch_index.search = Mock(
+            return_value={
+                "hits": [],
+                "facetDistribution": {},
+                "estimatedTotalHits": 0,
+                "processingTimeMs": 1,
+            }
+        )
+        engine.search(field_dictionary={"language": "en"}, is_multivalue=False)
+        engine._expand_facet_distibutions.assert_not_called()
+
+    def test_facet_expansion_is_triggered_if_multivalue(self):
+        engine = search.meilisearch.MeilisearchEngine(index="test_index")
+        engine._expand_facet_distibutions = MagicMock()
+        engine.meilisearch_index.search = Mock(
+            return_value={
+                "hits": [],
+                "facetDistribution": {},
+                "estimatedTotalHits": 0,
+                "processingTimeMs": 1,
+            }
+        )
+        engine.search(query_string="demo", field_dictionary={"language": ["en"]}, is_multivalue=True)
+        engine._expand_facet_distibutions.assert_called_once()
 
 
 class UtilitiesTests(django.test.TestCase):


### PR DESCRIPTION
Add logic to MeilisearchEngine to support filtering courses by multiple options within a single facet category.

- The changes are made in the meilisearch module, with one exception being api.course_discovery_search to make integration testing possible at this stage of development.
- Added unit tests and integration tests.
- A make command is added to make it easy to run tests in a docker container.