### PR TITLE
Feat/multi org based filter--back-end

### DIFF
--- a/search/api.py
+++ b/search/api.py
@@ -158,3 +158,29 @@ def course_discovery_search(search_term=None, size=20, from_=0, field_dictionary
     )
 
     return results
+
+# helper function for building filters from dicts (optional):
+# def build_filters(field_dictionary):
+#     """
+#     Convert field_dictionary into Elasticsearch filter clauses,
+#     using 'terms' for multi-value filters and 'term' for single-value filters.
+#     """
+#     filters = []
+#     for field, values in field_dictionary.items():
+#         if not isinstance(values, list):
+#             values = [values]
+
+#         if len(values) > 1:
+#             filters.append({
+#                 "terms": {
+#                     field: values
+#                 }
+#             })
+#         else:
+#             filters.append({
+#                 "term": {
+#                     field: values[0]
+#                 }
+#             })
+
+#     return filters

--- a/search/elastic.py
+++ b/search/elastic.py
@@ -192,6 +192,18 @@ def _process_filters(filter_dictionary):
             },
         }
 
+    # --- update to handle multiple fields --- 
+# def _process_filters(filter_dictionary):
+#     for field, value in filter_dictionary.items():
+#         if value:
+#             field_filter = _get_filter_field(field, value)
+#             # If the helper returns a list of filters, yield each filter one by one
+#             if isinstance(field_filter, list):
+#                 for multi_filter in field_filter:
+#                     yield multi_filter
+#             else:
+#                 #  If a single filter dictionary is returned, yield it directly 
+#                 yield field_filter
 
 def _process_exclude_dictionary(exclude_dictionary):
     """

--- a/search/filter_generator.py
+++ b/search/filter_generator.py
@@ -6,6 +6,7 @@ from django.conf import settings
 
 from .utils import _load_class, DateRange
 
+from typing import Any, Dict, List, Optional, Union
 
 class SearchFilterGenerator:
 
@@ -14,9 +15,38 @@ class SearchFilterGenerator:
     Users of this search app will override this class and update setting for SEARCH_FILTER_GENERATOR
     """
 
-    def filter_dictionary(self, **kwargs):
-        """ base implementation which filters via start_date """
-        return {"start_date": DateRange(None, datetime.utcnow())}
+    # def filter_dictionary(self, **kwargs):
+    #     """ base implementation which filters via start_date """
+    #     return {"start_date": DateRange(None, datetime.utcnow())}
+
+
+# changed filter_dictionary function to support the following
+#  Starts with a default start_date filter.
+
+# Then dynamically adds more filters based on the provided field_filters dictionary.
+
+# Uses term or terms queries depending on whether the value is a single item or a list.
+    @staticmethod
+    def _normalise_to_list(value: Any) -> List[Any]:
+        """
+        Return *value* as a list without mutating it if it already is one.
+        """
+        if isinstance(value, (list, tuple, set)):
+            return list(value)
+        return [value]
+
+    def filter_dictionary(self, *, field_filters=None, **_kwargs):
+        filters = {
+            "start_date": DateRange(None, datetime.utcnow())
+        }
+        if field_filters:
+            for field, raw in field_filters.items():
+                values = self._normalise_to_list(raw)
+                if len(values) == 1:
+                    filters[field] = {"term": {f"{field}.keyword": values[0]}}
+                else:
+                    filters[field] = {"terms": {f"{field}.keyword": values}}
+        return filters
 
     def field_dictionary(self, **kwargs):
         """ base implementation which add course if provided """

--- a/search/views.py
+++ b/search/views.py
@@ -1,47 +1,91 @@
 """ handle requests for courseware search http requests """
 # This contains just the url entry points to use if desired, which currently has only one
 
+import json
 import logging
 
 from django.conf import settings
-from django.http import JsonResponse
+from django.http import JsonResponse, QueryDict
 from django.utils.translation import gettext as _
 from django.views.decorators.http import require_POST
 
 from eventtracking import tracker as track
 from .api import perform_search, course_discovery_search, course_discovery_filter_fields
 from .initializer import SearchInitializer
-
+from django.views.decorators.csrf import csrf_exempt
 # log appears to be standard name used for logger
 log = logging.getLogger(__name__)
 
+def parse_post_data(request):
+    """Support both JSON and form-encoded input."""
+    if request.content_type == 'application/json':
+        try:
+            body = json.loads(request.body.decode('utf-8'))
+        except json.JSONDecodeError:
+            log.warning("⚠️ Malformed JSON received")
+            return QueryDict('', mutable=True)
 
-def _process_pagination_values(request):
-    """ process pagination requests from request parameter """
-    size = 20
-    page = 0
-    from_ = 0
-    if "page_size" in request.POST:
-        size = int(request.POST["page_size"])
-        max_page_size = getattr(settings, "SEARCH_MAX_PAGE_SIZE", 100)
-        # The parens below are superfluous, but make it much clearer to the reader what is going on
-        if not (0 < size <= max_page_size):  # pylint: disable=superfluous-parens
-            raise ValueError(_('Invalid page size of {page_size}').format(page_size=size))
+        qdict = QueryDict('', mutable=True)
+        for key, value in body.items():
+            if isinstance(value, list):
+                # ensure qdict.getlist("org") returns ['astu', 'openedx'], by appending lists 
+                for item in value:
+                    qdict.appendlist(key, item)
+            else:
+                qdict.update({key: value})
+        return qdict
+    # else return request.post 
+    return request.POST
+# def _process_pagination_values(request):
+#     """ process pagination requests from request parameter """
+#     size = 20
+#     page = 0
+#     from_ = 0
+#     if "page_size" in request.POST:
+#         size = int(request.POST["page_size"])
+#         max_page_size = getattr(settings, "SEARCH_MAX_PAGE_SIZE", 100)
+#         # The parens below are superfluous, but make it much clearer to the reader what is going on
+#         if not (0 < size <= max_page_size):  # pylint: disable=superfluous-parens
+#             raise ValueError(_('Invalid page size of {page_size}').format(page_size=size))
 
-        if "page_index" in request.POST:
-            page = int(request.POST["page_index"])
-            from_ = page * size
+#         if "page_index" in request.POST:
+#             page = int(request.POST["page_index"])
+#             from_ = page * size
+#     return size, from_, page
+
+def _process_pagination_values(data):
+    """Extract pagination info from data."""
+    size = int(data.get("page_size", 20))
+    page = int(data.get("page_index", 0))
+    max_page_size = getattr(settings, "SEARCH_MAX_PAGE_SIZE", 100)
+
+    if not (0 < size <= max_page_size):
+        raise ValueError(_('Invalid page size of {page_size}').format(page_size=size))
+
+    from_ = page * size
     return size, from_, page
 
+# def _process_field_values(request):
+#     """ Create separate dictionary of supported filter values provided """
+#     return {
+#         field_key: request.POST[field_key]
+#         for field_key in request.POST
+#         if field_key in course_discovery_filter_fields()
+#     }
 
-def _process_field_values(request):
-    """ Create separate dictionary of supported filter values provided """
-    return {
-        field_key: request.POST[field_key]
-        for field_key in request.POST
-        if field_key in course_discovery_filter_fields()
-    }
-
+# ----to support multiple values per key as QueryDict and regular dict like "org=astu&org=openedx" ----
+def _process_field_values(data):
+    filters = {}
+    for key in course_discovery_filter_fields():
+        if isinstance(data, QueryDict):
+            values = data.getlist(key)
+        else:
+            values = data.get(key, [])
+            if not isinstance(values, list):
+                values = [values]
+        if values:
+            filters[key] = values
+    return filters
 
 @require_POST
 def do_search(request, course_id=None):
@@ -137,6 +181,7 @@ def do_search(request, course_id=None):
 
 
 @require_POST
+@csrf_exempt
 def course_discovery(request):
     """
     Search for courses
@@ -165,12 +210,15 @@ def course_discovery(request):
     }
     status_code = 500
 
-    search_term = request.POST.get("search_string", None)
-
+    # search_term = request.POST.get("search_string", None)
+    post_data = parse_post_data(request)
+    search_term = post_data.get("search_string", "").strip()
     try:
-        size, from_, page = _process_pagination_values(request)
-        field_dictionary = _process_field_values(request)
-
+        size, from_, page = _process_pagination_values(post_data)
+        field_dictionary = _process_field_values(post_data)
+        # ✅ Allow searches even if search_string is empty, as long as filters are applied
+        if not search_term and not field_dictionary:
+            search_term = None
         # Analytics - log search request
         track.emit(
             'edx.course_discovery.search.initiated',
@@ -178,6 +226,7 @@ def course_discovery(request):
                 "search_term": search_term,
                 "page_size": size,
                 "page_number": page,
+                "filters": field_dictionary, #track filters information
             }
         )
 


### PR DESCRIPTION
Title: UX Issue with filters on course platform course seatch #36629

https://github.com/openedx/edx-platform/issues/36629

Description:
This pull request addresses a "UX Issue with filters on course platform course search" where selected filter options—particularly the organization filter—were disappeared after search execution, especially when a single organization was selected. On the backend, the issue identified from how filter values were processed and returned, particularly with the handling of  multiple values. This update enhances the backend logic to support multiple filter values (e.g., multiple organizations) by correctly parsing input data and constructing appropriate search queries. It also ensures the filtered state is preserved and returned in the response, allowing the frontend to reflect the selected filters accurately. The changes have been thoroughly tested to ensure reliable frontend-backend data exchange and consistent UI behavior.

What This Pull Request Changes: Customization in back-end files
File: 
      - search/api.py
      - search/elastic.py
      - search/filter_generator.py
      - search/views.py
      
Test: the changes tested through:
1. Postman API --- 
     - with method POST and url: http://local.openedx.io:8000/search/course_discovery/
     - body : {
    "search_string":"",
    "page_size":20,
    "page_index":0,
    "org":["astu","openedx"] or "org":["openedx"]  or  "org":[] 
   } 
   -  header: application/json
 2. Through browser or front-end by selecting orgs and observing contents returned and Dev tools ---responses under network.
Finally Confirmed: That back-end handle the multiple organization based filtering .