### PR TITLE
feat: Bump version to 4.3.0

### DIFF
--- a/edxsearch/__init__.py
+++ b/edxsearch/__init__.py
@@ -1,3 +1,3 @@
 """ Container module for testing / demoing search """
 
-__version__ = '4.2.0'
+__version__ = '4.3.0'


### PR DESCRIPTION
We didn't bump the version when https://github.com/openedx/edx-search/pull/205 landed.

This change bumps the version so we can release the new version of the library.