### PR TITLE
fix: add missing `course` filter attribute

### DIFF
--- a/search/meilisearch.py
+++ b/search/meilisearch.py
@@ -95,6 +95,7 @@ UTC_OFFSET_SUFFIX = "__utcoffset"
 # Note that index names are hard-coded here, because they are hardcoded anyway across all of edx-search.
 INDEX_FILTERABLES: dict[str, list[str]] = {
     getattr(settings, "COURSEWARE_INFO_INDEX_NAME", "course_info"): [
+        "course",
         "language",  # aggregate by language, mode, org
         "modes",
         "org",


### PR DESCRIPTION
# Description

This is used to delete courses.

(cherry picked from commit 1db1bfda59bf975303181b8d1a3b625325a6754a)




**Context & Issue:**
Currently, the course deletion functionality is broken. When attempting to delete a course using Meilisearch, the operation fails because the `course` attribute is not configured as a filterable parameter within the `COURSE_INFO_INDEX`. 

**Solution:**
This PR fixes the issue by adding `course` to the list of filterable attributes for the `COURSE_INFO_INDEX` https://github.com/openedx/openedx-platform/blob/5439a27f8522d74d63726ec266c0263a3bbfb69b/cms/djangoapps/contentstore/courseware_index.py#L669 , allowing Meilisearch to properly filter and execute the deletion.
https://github.com/openedx/openedx-platform/blob/22512ba78be63fc2c6ffe23637b76f31d1aed656/cms/djangoapps/contentstore/signals/handlers.py#L176

## Test
- create an empty course
- check if existence in the Meilisearch site
- delete the course via shell
```
tutor local run cms ./manage.py cms delete_course <course_id>
```
- Check the course is deleted in meilisearch
### Before

<img width="1893" height="770" alt="2026-07-02_17-07" src="https://github.com/user-attachments/assets/00926c5d-d8b4-4064-ba51-3ab435a6c0d3" />
<img width="1520" height="954" alt="2026-07-02_17-08" src="https://github.com/user-attachments/assets/a8526aa5-5d28-4646-9aec-382fe5c33eba" />
<img width="1640" height="931" alt="2026-07-02_17-10_1" src="https://github.com/user-attachments/assets/db419a0b-aa11-47a1-aa1f-016703a86dad" />


### After

<img width="1913" height="967" alt="2026-07-02_17-10" src="https://github.com/user-attachments/assets/df3089d0-adfc-4014-889a-5dc3738fc05e" />



<img width="1671" height="913" alt="2026-07-02_17-11" src="https://github.com/user-attachments/assets/582a7568-8407-4438-aaa3-472f5f2440ab" />

